### PR TITLE
[Hotfix] Fix search

### DIFF
--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -2,6 +2,7 @@ import { FormControl, FormControlProps } from 'react-bootstrap'
 
 interface ISearchBar extends FormControlProps {
   borderColor?: 'info' | 'primary' | 'success' | 'danger' | 'secondary'
+  name?: string
 }
 
 /** Thin wrapper around Bootstrap's FormControl for consistent SearchBar style */

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -30,6 +30,7 @@ export default function Search() {
           size="lg"
           placeholder="Search by agent or office"
           type="text"
+          name="search"
           defaultValue={searchParam}
           onChange={handleInput}
         />


### PR DESCRIPTION
Problem: recent SearchBar changes broke search functionality.

Reason: without the "name" attribute, the formData wasn't about to construct the expected object (`{ search: 'xyz' }`), and so the searchLoader couldn't construct the query properly.
