### PR TITLE
Attempt Typescript transpile as a CI action to catch Typescript errors

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,3 +21,4 @@ jobs:
       - run: pnpm i
       - run: pnpm lint
       - run: pnpm test
+      - run: pnpm tsc --noEmit

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -59,7 +59,7 @@ export default function Search() {
         {data &&
           data.map((r: Agent | Office) => (
             <SearchResult
-              result={r}
+              // result={r}
               key={`search-result-${r.id}-${r.type}`}
               onClick={handleResultClick(r)}
             />


### PR DESCRIPTION
Catch Typescript errors before letting CI tests pass. This should make errors easier to find and prevent Netlify from trying to build preview deployments unnecessarily.