### PR TITLE
[PRO-165] Password reset landing page for changing password

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@hookform/error-message": "^2.0.1",
     "@types/lodash": "^4.14.196",
     "axios": "^1.4.0",
     "bootstrap": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,9 @@ settings:
   excludeLinksFromLockfile: false
 
 dependencies:
+  '@hookform/error-message':
+    specifier: ^2.0.1
+    version: 2.0.1(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
   '@types/lodash':
     specifier: ^4.14.196
     version: 4.14.196
@@ -1794,6 +1797,18 @@ packages:
   /@floating-ui/utils@0.1.1:
     resolution: {integrity: sha512-m0G6wlnhm/AX0H12IOWtK8gASEMffnX08RtKkCgTdHb9JpHKGloI7icFfLg9ZmQeavcvR0PKmzxClyuFPSjKWw==}
     dev: true
+
+  /@hookform/error-message@2.0.1(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0):
+    resolution: {integrity: sha512-U410sAr92xgxT1idlu9WWOVjndxLdgPUHEB8Schr27C9eh7/xUnITWpCMF93s+lGiG++D4JnbSnrb5A21AdSNg==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+      react-hook-form: ^7.0.0
+    dependencies:
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-hook-form: 7.45.2(react@18.2.0)
+    dev: false
 
   /@humanwhocodes/config-array@0.11.10:
     resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}

--- a/src/api/passwordResets.ts
+++ b/src/api/passwordResets.ts
@@ -1,8 +1,38 @@
 import apiClient from './client'
 
+export async function get(token: string) {
+  const result = await apiClient
+    .get(`/auth/password_resets/${token}`)
+    .then((r) => r.status === 200)
+    .catch(() => false)
+
+  return result
+}
+
 export async function create({ email }: { email: string }) {
   const result = await apiClient
     .post('/auth/password_resets', { email })
+    .then((r) => r.data)
+    .catch(() => false)
+
+  return result
+}
+
+interface IApiPasswordResetsUpdateArgs {
+  newPassword: string
+  newPasswordConfirm: string
+  token: string
+}
+export async function update({
+  newPassword,
+  newPasswordConfirm,
+  token,
+}: IApiPasswordResetsUpdateArgs) {
+  const result = await apiClient
+    .patch(`/auth/password_resets/${token}`, {
+      newPassword,
+      newPasswordConfirm,
+    })
     .then((r) => r.data)
     .catch(() => false)
 

--- a/src/components/BasicPage.tsx
+++ b/src/components/BasicPage.tsx
@@ -1,12 +1,20 @@
+import { Card } from 'react-bootstrap'
+
 interface IBasicPage {
   title: string
   icon: string
   children: React.ReactNode
+  fullScreen?: boolean
 }
 
 /** Multi-purpose page layout with a page title and icon */
-export default function BasicPage({ title, icon, children }: IBasicPage) {
-  return (
+export default function BasicPage({
+  title,
+  icon,
+  children,
+  fullScreen,
+}: IBasicPage) {
+  const inner = (
     <div className="px-4 pb-4 pt-5">
       <div className="d-flex justify-content-center mb-4">
         <div
@@ -19,5 +27,15 @@ export default function BasicPage({ title, icon, children }: IBasicPage) {
       <h2 className="mb-4 text-center">{title}</h2>
       {children}
     </div>
+  )
+
+  return fullScreen ? (
+    <div className="w-100 d-flex flex-column p-5 align-items-center vh-100 bg-light">
+      <Card style={{ top: '30%' }}>
+        <Card.Body className="p-0">{inner}</Card.Body>
+      </Card>
+    </div>
+  ) : (
+    inner
   )
 }

--- a/src/components/PasswordResets/PasswordResetsForm.tsx
+++ b/src/components/PasswordResets/PasswordResetsForm.tsx
@@ -1,0 +1,87 @@
+import { ErrorMessage } from '@hookform/error-message'
+import { Button, FloatingLabel, FormControl } from 'react-bootstrap'
+import { SubmitHandler, useForm } from 'react-hook-form'
+import { Link } from 'react-router-dom'
+
+interface IPasswordResetsFormState {
+  newPassword: string
+  newPasswordConfirm: string
+}
+
+interface IPasswordResetsForm {
+  onSubmit: SubmitHandler<IPasswordResetsFormState>
+}
+export default function PasswordResetsForm({ onSubmit }: IPasswordResetsForm) {
+  const {
+    register,
+    watch,
+    getFieldState,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = useForm({
+    mode: 'onTouched',
+    defaultValues: {
+      newPassword: '',
+      newPasswordConfirm: '',
+    },
+  })
+
+  function validationProps(fieldName: 'newPassword' | 'newPasswordConfirm'): {
+    isValid: boolean
+    isInvalid: boolean
+  } {
+    const { isTouched, invalid, error } = getFieldState(fieldName)
+
+    return {
+      isValid: isTouched && !invalid,
+      isInvalid: isTouched && !!error,
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm px-2">
+      <FloatingLabel label="New Password">
+        <FormControl
+          type="password"
+          placeholder="SecurePassword123"
+          {...validationProps('newPassword')}
+          autoComplete="false"
+          {...register('newPassword', {
+            required: 'Password is required',
+            minLength: {
+              value: 8,
+              message: 'Password must be at least 8 characters long',
+            },
+          })}
+        />
+        <FormControl.Feedback type="invalid">
+          <ErrorMessage errors={errors} name="newPassword" />
+        </FormControl.Feedback>
+      </FloatingLabel>
+      <FloatingLabel label="Confirm New Password">
+        <FormControl
+          type="password"
+          placeholder="SecurePassword12334"
+          autoComplete="false"
+          {...validationProps('newPasswordConfirm')}
+          {...register('newPasswordConfirm', {
+            required: 'Password confirmation is required',
+            validate: (value) =>
+              value === watch('newPassword') || 'Passwords do not match',
+          })}
+        />
+        <FormControl.Feedback type="invalid">
+          <ErrorMessage errors={errors} name="newPasswordConfirm" />
+        </FormControl.Feedback>
+      </FloatingLabel>
+      <div className="d-flex flex-row justify-content-between">
+        <Link className="col btn btn-tertiary btn-lg me-3" to="/">
+          Cancel
+        </Link>
+        <Button type="submit" size="lg" disabled={isDirty && !isValid}>
+          Update password
+        </Button>
+      </div>
+    </form>
+  )
+}

--- a/src/components/PasswordResets/SuccessModal.tsx
+++ b/src/components/PasswordResets/SuccessModal.tsx
@@ -1,0 +1,18 @@
+import { Modal, ModalBody, ModalFooter } from 'react-bootstrap'
+import { Link } from 'react-router-dom'
+
+export default function SuccessModal({ show }: { show: boolean }) {
+  return (
+    <Modal show={show} centered>
+      <ModalBody className="py-5 text-center">
+        <i className="bi bi-check-circle text-success fs-1" />
+        <h3 className="text-center">Password change successful</h3>
+      </ModalBody>
+      <ModalFooter className="border-0">
+        <Link className="col btn btn-primary btn-lg me-3" to="/" replace={true}>
+          Please sign in
+        </Link>
+      </ModalFooter>
+    </Modal>
+  )
+}

--- a/src/pages/Confirmation.tsx
+++ b/src/pages/Confirmation.tsx
@@ -5,6 +5,7 @@ import icon from '../images/icon.svg'
 import { ApiConfirmations } from 'src/api'
 import toast from 'react-hot-toast'
 import { useAuth } from 'src/contexts/auth/AuthContext'
+import BasicPage from 'src/components/BasicPage'
 
 export default function Confirmation() {
   const params = useParams()
@@ -45,11 +46,11 @@ export default function Confirmation() {
   }, [navigate, params, refreshUser])
 
   return (
-    <div className="w-100 d-flex justify-content-center flex-column py-5 align-items-center vh-100">
-      <img src={icon} alt="Project Protocol Logo" className="mb-3" />
-      <h1 className="mb-3">Email confirmation</h1>
-      <p>Please wait...</p>
-      <Spinner />
-    </div>
+    <BasicPage title="Email confirmation" icon={icon} fullScreen>
+      <div className="text-center vertical-rhythm">
+        <p>Please wait...</p>
+        <Spinner />
+      </div>
+    </BasicPage>
   )
 }

--- a/src/pages/ErrorPage.tsx
+++ b/src/pages/ErrorPage.tsx
@@ -1,4 +1,7 @@
-import { useRouteError } from 'react-router-dom'
+import { Link, useRouteError } from 'react-router-dom'
+import BasicPage from 'src/components/BasicPage'
+import icon from '../images/icon.svg'
+
 type RoutingError = {
   statusText?: string
   message?: string
@@ -7,13 +10,20 @@ type RoutingError = {
 export default function ErrorPage() {
   const error = useRouteError() as RoutingError
 
+  const text = error?.statusText || error?.message || 'Something went wrong.'
+
   return (
-    <div id="error-page">
-      <h1>Oops!</h1>
-      <p>Sorry, an unexpected error has occurred.</p>
-      <p>
-        <i>{error?.statusText || error?.message}</i>
-      </p>
+    <div className="vh-100 d-flex flex-column align-items-center">
+      <div className="text-center" style={{ marginTop: '33%' }}>
+        <BasicPage title="Oops!" icon={icon}>
+          <p>{text}</p>
+          <p>
+            <Link to="/" replace={true}>
+              Main page
+            </Link>
+          </p>
+        </BasicPage>
+      </div>
     </div>
   )
 }

--- a/src/pages/PasswordResets.tsx
+++ b/src/pages/PasswordResets.tsx
@@ -1,0 +1,156 @@
+import {
+  Button,
+  Card,
+  FloatingLabel,
+  FormControl,
+  FormGroup,
+  Modal,
+  ModalBody,
+  ModalFooter,
+} from 'react-bootstrap'
+import icon from '../images/icon.svg'
+import BasicPage from 'src/components/BasicPage'
+import { useForm } from 'react-hook-form'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useEffect, useState } from 'react'
+import { ApiPasswordResets } from 'src/api'
+import toast from 'react-hot-toast'
+import { ErrorMessage } from '@hookform/error-message'
+
+interface IPasswordResetsFormState {
+  newPassword: string
+  newPasswordConfirm: string
+}
+
+export default function PasswordResets() {
+  const { token } = useParams()
+  const [success, setSuccess] = useState(false)
+  const navigate = useNavigate()
+  const {
+    register,
+    watch,
+    getFieldState,
+    handleSubmit,
+    formState: { errors, isValid, isDirty },
+  } = useForm({
+    mode: 'onTouched',
+    defaultValues: {
+      newPassword: '',
+      newPasswordConfirm: '',
+    },
+  })
+
+  useEffect(() => {
+    async function validateToken() {
+      const isValid = await ApiPasswordResets.get(token || '')
+      if (!isValid) {
+        toast.error('Password reset has expired, please try again', {
+          id: 'invalid-pw-reset-token',
+        })
+        navigate('/', { replace: true })
+      }
+    }
+    validateToken()
+  }, [token, navigate])
+
+  function validationProps(fieldName: 'newPassword' | 'newPasswordConfirm'): {
+    isValid: boolean
+    isInvalid: boolean
+  } {
+    const { isTouched, invalid, error } = getFieldState(fieldName)
+
+    return {
+      isValid: isTouched && !invalid,
+      isInvalid: isTouched && !!error,
+    }
+  }
+
+  const onSubmit = async ({
+    newPassword,
+    newPasswordConfirm,
+  }: IPasswordResetsFormState) => {
+    if (token === undefined) throw new Error('Invalid request')
+
+    const result = await ApiPasswordResets.update({
+      newPassword,
+      newPasswordConfirm,
+      token,
+    })
+    if (result) {
+      setSuccess(true)
+    } else {
+      toast.error('Password change failed, please try again.')
+      navigate('/', { replace: true })
+    }
+  }
+
+  return (
+    <div className="w-100 d-flex flex-column py-5 align-items-center vh-100 bg-light justify-content-center">
+      <Card body>
+        <BasicPage icon={icon} title="New password">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <FormGroup className="mb-3">
+              <FloatingLabel label="New Password">
+                <FormControl
+                  type="password"
+                  placeholder="SecurePassword123"
+                  {...validationProps('newPassword')}
+                  autoComplete="false"
+                  {...register('newPassword', {
+                    required: 'Password is required',
+                    minLength: {
+                      value: 8,
+                      message: 'Password must be at least 8 characters long',
+                    },
+                  })}
+                />
+                <FormControl.Feedback type="invalid">
+                  <ErrorMessage errors={errors} name="newPassword" />
+                </FormControl.Feedback>
+              </FloatingLabel>
+            </FormGroup>
+            <FloatingLabel label="Confirm New Password" className="mb-3">
+              <FormControl
+                type="password"
+                placeholder="SecurePassword12334"
+                autoComplete="false"
+                {...validationProps('newPasswordConfirm')}
+                {...register('newPasswordConfirm', {
+                  required: 'Password confirmation is required',
+                  validate: (value) =>
+                    value === watch('newPassword') || 'Passwords do not match',
+                })}
+              />
+              <FormControl.Feedback type="invalid">
+                <ErrorMessage errors={errors} name="newPasswordConfirm" />
+              </FormControl.Feedback>
+            </FloatingLabel>
+            <div className="d-flex flex-row justify-content-between">
+              <Link className="col btn btn-tertiary btn-lg me-3" to="/">
+                Cancel
+              </Link>
+              <Button type="submit" size="lg" disabled={isDirty && !isValid}>
+                Update password
+              </Button>
+            </div>
+          </form>
+        </BasicPage>
+      </Card>
+      <Modal show={success} centered>
+        <ModalBody className="py-5 text-center">
+          <i className="bi bi-check-circle text-success fs-1" />
+          <h3 className="text-center">Password change successful</h3>
+        </ModalBody>
+        <ModalFooter className="border-0">
+          <Link
+            className="col btn btn-primary btn-lg me-3"
+            to="/"
+            replace={true}
+          >
+            Please sign in
+          </Link>
+        </ModalFooter>
+      </Modal>
+    </div>
+  )
+}

--- a/src/pages/PasswordResets.tsx
+++ b/src/pages/PasswordResets.tsx
@@ -1,19 +1,11 @@
-import {
-  Button,
-  FloatingLabel,
-  FormControl,
-  Modal,
-  ModalBody,
-  ModalFooter,
-} from 'react-bootstrap'
 import icon from '../images/icon.svg'
 import BasicPage from 'src/components/BasicPage'
-import { useForm } from 'react-hook-form'
-import { Link, useNavigate, useParams } from 'react-router-dom'
+import { useNavigate, useParams } from 'react-router-dom'
 import { useEffect, useState } from 'react'
 import { ApiPasswordResets } from 'src/api'
 import toast from 'react-hot-toast'
-import { ErrorMessage } from '@hookform/error-message'
+import PasswordResetsForm from 'src/components/PasswordResets/PasswordResetsForm'
+import SuccessModal from 'src/components/PasswordResets/SuccessModal'
 
 interface IPasswordResetsFormState {
   newPassword: string
@@ -24,19 +16,6 @@ export default function PasswordResets() {
   const { token } = useParams()
   const [success, setSuccess] = useState(false)
   const navigate = useNavigate()
-  const {
-    register,
-    watch,
-    getFieldState,
-    handleSubmit,
-    formState: { errors, isValid, isDirty },
-  } = useForm({
-    mode: 'onTouched',
-    defaultValues: {
-      newPassword: '',
-      newPasswordConfirm: '',
-    },
-  })
 
   useEffect(() => {
     async function validateToken() {
@@ -51,19 +30,7 @@ export default function PasswordResets() {
     validateToken()
   }, [token, navigate])
 
-  function validationProps(fieldName: 'newPassword' | 'newPasswordConfirm'): {
-    isValid: boolean
-    isInvalid: boolean
-  } {
-    const { isTouched, invalid, error } = getFieldState(fieldName)
-
-    return {
-      isValid: isTouched && !invalid,
-      isInvalid: isTouched && !!error,
-    }
-  }
-
-  const onSubmit = async ({
+  const updatePassword = async ({
     newPassword,
     newPasswordConfirm,
   }: IPasswordResetsFormState) => {
@@ -84,65 +51,8 @@ export default function PasswordResets() {
 
   return (
     <BasicPage icon={icon} title="New password" fullScreen>
-      <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm px-2">
-        <FloatingLabel label="New Password">
-          <FormControl
-            type="password"
-            placeholder="SecurePassword123"
-            {...validationProps('newPassword')}
-            autoComplete="false"
-            {...register('newPassword', {
-              required: 'Password is required',
-              minLength: {
-                value: 8,
-                message: 'Password must be at least 8 characters long',
-              },
-            })}
-          />
-          <FormControl.Feedback type="invalid">
-            <ErrorMessage errors={errors} name="newPassword" />
-          </FormControl.Feedback>
-        </FloatingLabel>
-        <FloatingLabel label="Confirm New Password">
-          <FormControl
-            type="password"
-            placeholder="SecurePassword12334"
-            autoComplete="false"
-            {...validationProps('newPasswordConfirm')}
-            {...register('newPasswordConfirm', {
-              required: 'Password confirmation is required',
-              validate: (value) =>
-                value === watch('newPassword') || 'Passwords do not match',
-            })}
-          />
-          <FormControl.Feedback type="invalid">
-            <ErrorMessage errors={errors} name="newPasswordConfirm" />
-          </FormControl.Feedback>
-        </FloatingLabel>
-        <div className="d-flex flex-row justify-content-between">
-          <Link className="col btn btn-tertiary btn-lg me-3" to="/">
-            Cancel
-          </Link>
-          <Button type="submit" size="lg" disabled={isDirty && !isValid}>
-            Update password
-          </Button>
-        </div>
-      </form>
-      <Modal show={success} centered>
-        <ModalBody className="py-5 text-center">
-          <i className="bi bi-check-circle text-success fs-1" />
-          <h3 className="text-center">Password change successful</h3>
-        </ModalBody>
-        <ModalFooter className="border-0">
-          <Link
-            className="col btn btn-primary btn-lg me-3"
-            to="/"
-            replace={true}
-          >
-            Please sign in
-          </Link>
-        </ModalFooter>
-      </Modal>
+      <PasswordResetsForm onSubmit={updatePassword} />
+      <SuccessModal show={success} />
     </BasicPage>
   )
 }

--- a/src/pages/PasswordResets.tsx
+++ b/src/pages/PasswordResets.tsx
@@ -1,9 +1,7 @@
 import {
   Button,
-  Card,
   FloatingLabel,
   FormControl,
-  FormGroup,
   Modal,
   ModalBody,
   ModalFooter,
@@ -85,57 +83,51 @@ export default function PasswordResets() {
   }
 
   return (
-    <div className="w-100 d-flex flex-column py-5 align-items-center vh-100 bg-light justify-content-center">
-      <Card body>
-        <BasicPage icon={icon} title="New password">
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <FormGroup className="mb-3">
-              <FloatingLabel label="New Password">
-                <FormControl
-                  type="password"
-                  placeholder="SecurePassword123"
-                  {...validationProps('newPassword')}
-                  autoComplete="false"
-                  {...register('newPassword', {
-                    required: 'Password is required',
-                    minLength: {
-                      value: 8,
-                      message: 'Password must be at least 8 characters long',
-                    },
-                  })}
-                />
-                <FormControl.Feedback type="invalid">
-                  <ErrorMessage errors={errors} name="newPassword" />
-                </FormControl.Feedback>
-              </FloatingLabel>
-            </FormGroup>
-            <FloatingLabel label="Confirm New Password" className="mb-3">
-              <FormControl
-                type="password"
-                placeholder="SecurePassword12334"
-                autoComplete="false"
-                {...validationProps('newPasswordConfirm')}
-                {...register('newPasswordConfirm', {
-                  required: 'Password confirmation is required',
-                  validate: (value) =>
-                    value === watch('newPassword') || 'Passwords do not match',
-                })}
-              />
-              <FormControl.Feedback type="invalid">
-                <ErrorMessage errors={errors} name="newPasswordConfirm" />
-              </FormControl.Feedback>
-            </FloatingLabel>
-            <div className="d-flex flex-row justify-content-between">
-              <Link className="col btn btn-tertiary btn-lg me-3" to="/">
-                Cancel
-              </Link>
-              <Button type="submit" size="lg" disabled={isDirty && !isValid}>
-                Update password
-              </Button>
-            </div>
-          </form>
-        </BasicPage>
-      </Card>
+    <BasicPage icon={icon} title="New password" fullScreen>
+      <form onSubmit={handleSubmit(onSubmit)} className="vertical-rhythm px-2">
+        <FloatingLabel label="New Password">
+          <FormControl
+            type="password"
+            placeholder="SecurePassword123"
+            {...validationProps('newPassword')}
+            autoComplete="false"
+            {...register('newPassword', {
+              required: 'Password is required',
+              minLength: {
+                value: 8,
+                message: 'Password must be at least 8 characters long',
+              },
+            })}
+          />
+          <FormControl.Feedback type="invalid">
+            <ErrorMessage errors={errors} name="newPassword" />
+          </FormControl.Feedback>
+        </FloatingLabel>
+        <FloatingLabel label="Confirm New Password">
+          <FormControl
+            type="password"
+            placeholder="SecurePassword12334"
+            autoComplete="false"
+            {...validationProps('newPasswordConfirm')}
+            {...register('newPasswordConfirm', {
+              required: 'Password confirmation is required',
+              validate: (value) =>
+                value === watch('newPassword') || 'Passwords do not match',
+            })}
+          />
+          <FormControl.Feedback type="invalid">
+            <ErrorMessage errors={errors} name="newPasswordConfirm" />
+          </FormControl.Feedback>
+        </FloatingLabel>
+        <div className="d-flex flex-row justify-content-between">
+          <Link className="col btn btn-tertiary btn-lg me-3" to="/">
+            Cancel
+          </Link>
+          <Button type="submit" size="lg" disabled={isDirty && !isValid}>
+            Update password
+          </Button>
+        </div>
+      </form>
       <Modal show={success} centered>
         <ModalBody className="py-5 text-center">
           <i className="bi bi-check-circle text-success fs-1" />
@@ -151,6 +143,6 @@ export default function PasswordResets() {
           </Link>
         </ModalFooter>
       </Modal>
-    </div>
+    </BasicPage>
   )
 }

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -21,11 +21,13 @@ import Home from './pages/Home.tsx'
 import Confirmation from './pages/Confirmation.tsx'
 import createStaticPageLoader from './loaders/staticPageLoader.ts'
 import Account from './pages/Account.tsx'
+import PasswordResets from './pages/PasswordResets.tsx'
 
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
       <Route path="confirmations/:token" element={<Confirmation />} />
+      <Route path="password_resets/:token" element={<PasswordResets />} />
       <Route path="/" element={<Home />} errorElement={<ErrorPage />}>
         <Route errorElement={<ErrorPage />}>
           <Route index element={<Search />} loader={searchLoader} />

--- a/src/styles/colors.scss
+++ b/src/styles/colors.scss
@@ -1,3 +1,5 @@
+// https://github.com/twbs/bootstrap/blob/main/scss/_variables.scss
+
 // ProPro Colors
 $propro-gray-1: #f0f0f0;
 $propro-gray-2: #c9c9c9;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -22,3 +22,4 @@ $theme-colors: map-merge($theme-colors, $custom-colors);
 
 // 5. Additional customizations
 @import './links.scss';
+@import './utils.scss';

--- a/src/styles/utils.scss
+++ b/src/styles/utils.scss
@@ -1,0 +1,3 @@
+.vertical-rhythm > * {
+  margin-bottom: map-get($spacers, 4);
+}


### PR DESCRIPTION
* Adds the `/password_resets/:token` page for setting a new password.
* Redirects if token is invalid (or expired)
* Normalizes full-page UIs by adding the `fullScreen` variant to BasicPage component. Currently used for both `/confirmations/<token>` and `/password_resets/<token>` routes.

### Clickthrough (LOCAL! 😆 🤣 )
Clickthrough steps are for local environment with API/mailcatcher running, and FRONTEND_HOST set to your ngrok address in the `.env` file of your rails repo.

1. Trigger password reset email via forgot password? flow (test@user.com recommended).
2. See email come through in mailcatcher
3. Click link in email and be taken to the password reset page.
4. Note that this page will redirect if the token is invalid (try changing the token), or if you try to access the page after 15 minutes (token expires after 15 minutes).
5. Set a new password/confirmation and submit the form.
6. Test that you can login with new password.

<img width="30%" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/0ea64bc7-7ee5-4fc6-9b93-12e43272b4bc">
<img width="30%" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/bd2ccf74-569b-491e-aed2-9744f53d36c3">
<img width="30%" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/f5c69bc4-850a-45ce-9a9d-c2fc558c528b">
<img width="30%" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/bf3b4a0f-b4cf-476c-a44c-d14204e0b889">


