### PR TITLE
[hotfix] popup modal

### DIFF
--- a/src/components/PopUp.tsx
+++ b/src/components/PopUp.tsx
@@ -14,11 +14,12 @@ export default function PopUp({
   title,
   titleHelper,
   icon,
+  closeButton,
   ...props
 }: IPopUp) {
   return (
     <Modal centered size="sm" {...props}>
-      <Modal.Header closeButton={props.closeButton} />
+      <Modal.Header closeButton={closeButton} />
       <Modal.Body className={bodyClass}>
         {title && (
           <div className="mb-3">

--- a/src/test/components/PopUp.test.tsx
+++ b/src/test/components/PopUp.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react'
+import PopUp from 'src/components/PopUp'
+import { it, expect } from 'vitest'
+
+const defaultProps = {
+  title: 'Test Popup',
+  show: true,
+}
+
+const renderPopUp = (props = {}) => {
+  const mergeProps = { ...defaultProps, ...props }
+  return render(<PopUp {...mergeProps} />)
+}
+
+it('matches the snapshot', async () => {
+  const { baseElement } = renderPopUp()
+  expect(baseElement).toMatchSnapshot()
+})
+
+it('does not have a close button by default', async () => {
+  const { baseElement } = renderPopUp()
+  expect(baseElement.querySelector('.btn-close')).toBeFalsy()
+})
+
+it('renders a close button if specified', async () => {
+  const { baseElement } = renderPopUp({ closeButton: true })
+  expect(baseElement.querySelector('.btn-close')).toBeTruthy()
+})
+
+it('renders the title', async () => {
+  render(<PopUp title="Test Popup" show={true} />)
+  expect(screen.getByRole('heading').textContent).toBe('Test Popup')
+})
+
+it('does not render title helper if empty', () => {
+  const { baseElement } = renderPopUp()
+  expect(baseElement.querySelector('p')).toBeFalsy()
+})
+
+it('renders title helper text if given', async () => {
+  const { baseElement } = renderPopUp({ titleHelper: 'I am additional text' })
+  expect(baseElement.querySelector('p')?.textContent).toEqual(
+    'I am additional text',
+  )
+})

--- a/src/test/components/__snapshots__/PopUp.test.tsx.snap
+++ b/src/test/components/__snapshots__/PopUp.test.tsx.snap
@@ -1,0 +1,50 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`matches the snapshot 1`] = `
+<body
+  class="modal-open"
+  data-rr-ui-modal-open=""
+  style="padding-right: 1024px;"
+>
+  <div />
+  <div
+    class="fade modal-backdrop show"
+  />
+  <div
+    aria-modal="true"
+    class="fade modal show"
+    role="dialog"
+    style="display: block; padding-right: 0px;"
+    tabindex="-1"
+  >
+    <div
+      class="modal-dialog modal-sm modal-dialog-centered"
+    >
+      <div
+        class="modal-content"
+      >
+        <div
+          class="modal-header"
+        />
+        <div
+          class="modal-body"
+        >
+          <div
+            class="mb-3"
+          >
+            <h3>
+              <img
+                alt="Project protocol logo"
+                class="me-2"
+                src="/src/images/icon.svg"
+                style="height: 1.125rem;"
+              />
+              Test Popup
+            </h3>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</body>
+`;


### PR DESCRIPTION
Fixes a bug where closeButton was being passed along to the underlying modal component, rather than extracted for the ModalHeader component.

Clickthrough: test that this error doesn't occur when opening a modal
![image](https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/a9e52e16-e3da-41fc-8194-03d40cb08ac7)

