### PR TITLE
PRO-184 Modal adjustments and others

### DIFF
--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -39,10 +39,10 @@ export default function Menu({ user, openLogin }: IMenu) {
               alt="Project Protocol Logo"
             />
             <span
-              className="text-brand fs-2 w-100 d-none d-md-inline fw-medium"
+              className="fs-2 w-100 d-none d-md-inline fw-medium"
               style={{ letterSpacing: -0.5 }}
             >
-              ProjectProtocol
+              Project Protocol
             </span>
           </div>
         </Navbar.Brand>

--- a/src/components/PasswordResets/SuccessModal.tsx
+++ b/src/components/PasswordResets/SuccessModal.tsx
@@ -5,7 +5,7 @@ export default function SuccessModal({ show }: { show: boolean }) {
   return (
     <PopUp show={show}>
       <div className="text-center">
-        <h3 className="text-center">Password change successful</h3>
+        <h3 className="text-center">Password reset successful</h3>
         <div className="py-4">
           <i className="bi bi-check-circle text-success fs-1" />
           <p>You can now sign in to your account using your new password.</p>

--- a/src/components/PopUp.tsx
+++ b/src/components/PopUp.tsx
@@ -18,7 +18,7 @@ export default function PopUp({
   ...props
 }: IPopUp) {
   return (
-    <Modal centered size="sm" {...props}>
+    <Modal centered {...props}>
       <Modal.Header closeButton={closeButton} />
       <Modal.Body className={bodyClass}>
         {title && (

--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -61,9 +61,7 @@ export default function RateAgentModal({
     <PopUp
       title="Rate agent"
       show={show}
-      size={undefined}
       fullscreen="sm-down"
-      bodyClass="px-5"
       onHide={onHide}
       closeButton
       centered={false}

--- a/src/components/SearchResult.tsx
+++ b/src/components/SearchResult.tsx
@@ -3,15 +3,20 @@ import Office from '../types/Office'
 import SearchResultAgent from './SearchResultAgent'
 import SearchResultOffice from './SearchResultOffice'
 import ListItem from './List/ListItem'
+import { CardProps } from 'react-bootstrap'
 
-interface ISearchResult {
+interface ISearchResult extends CardProps {
   result: Agent | Office
   onClick?: () => void
 }
 
-export default function SearchResult({ result, onClick }: ISearchResult) {
+export default function SearchResult({
+  result,
+  onClick,
+  ...cardProps
+}: ISearchResult) {
   return (
-    <ListItem onClick={onClick} body>
+    <ListItem onClick={onClick} body {...cardProps}>
       {result.type === 'Agent' ? (
         <SearchResultAgent agent={result as Agent} />
       ) : (

--- a/src/components/SelectOfficeModal.tsx
+++ b/src/components/SelectOfficeModal.tsx
@@ -33,6 +33,7 @@ export default function SelectOfficeModal({
       size={undefined}
       scrollable
       centered={false}
+      bodyClass="p-3"
       onHide={close}
     >
       <div className="pt-3">
@@ -53,9 +54,9 @@ export default function SelectOfficeModal({
                 ? offices.length + ` Result`
                 : offices.length + ` Results`}{' '}
             </p>
-            <div>
+            <div className="vertical-rhythm">
               {offices.length === 0 ? (
-                <p className="m-5 p-4">
+                <p className="text-center my-5">
                   No results found. Please try a different search.
                 </p>
               ) : (
@@ -64,13 +65,14 @@ export default function SelectOfficeModal({
                     result={r as Office}
                     key={r.id}
                     onClick={() => handleOfficeClick(r)}
+                    className="border"
                   />
                 ))
               )}
             </div>
           </div>
         ) : (
-          <p className="m-5">
+          <p className="text-center my-5">
             Search for an office using the address or city name.
           </p>
         )}

--- a/src/styles/bootstrap-theme/modals.scss
+++ b/src/styles/bootstrap-theme/modals.scss
@@ -1,1 +1,2 @@
 $modal-content-border-width: 0;
+$modal-md: 430px;

--- a/src/test/components/__snapshots__/PopUp.test.tsx.snap
+++ b/src/test/components/__snapshots__/PopUp.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`matches the snapshot 1`] = `
     tabindex="-1"
   >
     <div
-      class="modal-dialog modal-sm modal-dialog-centered"
+      class="modal-dialog modal-dialog-centered"
     >
       <div
         class="modal-content"


### PR DESCRIPTION
Description
---
First few adjustments following @peiitforward 's design review.

* Unsets the default `size="sm"` on our PopUp component. Modals still aren't perfect, but it makes a lot more sense to let them be medium-sized by default.
* Adjusts PopUp instances throughout the app to look correct after the base style adjustments.
* Adjusts color of "Project Protocol" in navbar, adds a space (Fixes PRO-190).


Screenshots
---
<img width="647" alt="Screenshot 2023-11-08 at 10 47 31 AM" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/2d4daa6f-006c-4f72-bb48-7fe130a7616b">
<img width="590" alt="Screenshot 2023-11-08 at 10 47 42 AM" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/57572213-d66d-4401-8810-87f9fd562261">
<img width="532" alt="Screenshot 2023-11-08 at 11 21 32 AM" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/3f853eb0-3c3c-4f5f-a077-5ce4f81e542c">
<img width="723" alt="Screenshot 2023-11-08 at 10 47 47 AM" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/6b52362b-80f2-49e9-8caa-d89650e80d23">

