### PR TITLE
[PRO-188] Update theme colors for contrast

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -14,11 +14,11 @@ const links = [
 
 export default function Footer() {
   return (
-    <div className="bg-primary text-center py-4 mt-auto">
+    <div className="bg-white text-center p-4 mt-auto">
       {links.map(({ label, url }: FooterLink) => (
         <Link
           key={`footer-link-${label}`}
-          className="me-5 text-body d-block d-md-inline my-3 text-decoration-none w-100 text-center"
+          className="mx-3 my-3 d-block d-md-inline text-center"
           to={url}
         >
           {label}

--- a/src/components/Menu/MenuLinks.tsx
+++ b/src/components/Menu/MenuLinks.tsx
@@ -29,17 +29,15 @@ export default function MenuLinks({ isSignedIn, openLogin }: IMenuLinks) {
           </Nav.Link>
         </>
       ) : (
-        <>
+        <Nav.Link>
           <Button
-            variant="brand"
             onClick={() => {
               openLogin(LOGIN_PAGES.SIGN_UP)
             }}
-            className="mx-2 rounded rounded-5"
           >
             {t('navigation.signUp')}
           </Button>
-        </>
+        </Nav.Link>
       )}
       <Nav.Link>
         <LocaleSwitcher />

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -42,7 +42,7 @@ export default function Menu({ user, openLogin }: IMenu) {
               alt="Project Protocol Logo"
             />
             <span
-              className="fs-2 w-100 d-none d-md-inline fw-medium pe-auto"
+              className="fs-2 w-100 d-none d-md-inline fw-medium pe-auto text-body"
               style={{ letterSpacing: -0.5 }}
             >
               Project Protocol

--- a/src/components/Menu/index.tsx
+++ b/src/components/Menu/index.tsx
@@ -30,7 +30,10 @@ export default function Menu({ user, openLogin }: IMenu) {
     <Navbar className="bg-white" sticky="top">
       <Container style={{ maxWidth: 935 }}>
         <Navbar.Brand onClick={() => navigate('')}>
-          <div className="d-flex flex-row justify-content-center align-items-center">
+          <div
+            className="d-flex flex-row justify-content-center align-items-center"
+            role="button"
+          >
             <img
               src={icon}
               width="30"
@@ -39,7 +42,7 @@ export default function Menu({ user, openLogin }: IMenu) {
               alt="Project Protocol Logo"
             />
             <span
-              className="fs-2 w-100 d-none d-md-inline fw-medium"
+              className="fs-2 w-100 d-none d-md-inline fw-medium pe-auto"
               style={{ letterSpacing: -0.5 }}
             >
               Project Protocol
@@ -47,12 +50,12 @@ export default function Menu({ user, openLogin }: IMenu) {
           </div>
         </Navbar.Brand>
         <span
-          className="text-brand fs-2 w-100 text-center d-md-none fw-medium"
+          className="fs-2 w-100 text-center d-md-none fw-medium"
           style={{ letterSpacing: -0.5 }}
         >
-          ProjectProtocol
+          Project Protocol
         </span>
-        <Nav className="fs-4 d-none d-md-flex">
+        <Nav className="fs-4 d-none d-md-flex align-items-center">
           <MenuLinks isSignedIn={!!user} openLogin={openLogin} />
         </Nav>
         <div className="d-md-none">

--- a/src/components/RatingsBadge/index.tsx
+++ b/src/components/RatingsBadge/index.tsx
@@ -11,14 +11,21 @@ export default function RatingsBadge({ rating }: IRatingsBadge) {
   const decimal = rating % 1 > 0 ? (rating % 1).toPrecision(1).slice(1) : null
   const integer = Math.floor(rating)
   const properties = svgProps
-  const fill = ratingColors[integer - 1] || '#C9C9C9'
+  const badgeFill = ratingColors[integer - 1] || '#C9C9C9'
+  const textFill = integer === 1 ? 'white' : 'black'
 
   return (
     <svg {...properties.svg}>
-      <path {...properties.path} fill={fill} />
+      <path {...properties.path} fill={badgeFill} />
       <text {...properties.text} fontWeight={700}>
-        <tspan {...properties.integer}>{integer || '0'}</tspan>
-        {decimal && <tspan {...properties.decimal}>{decimal}</tspan>}
+        <tspan {...properties.integer} fill={textFill}>
+          {integer || '0'}
+        </tspan>
+        {decimal && (
+          <tspan {...properties.decimal} fill={textFill}>
+            {decimal}
+          </tspan>
+        )}
       </text>
     </svg>
   )

--- a/src/components/RatingsBadge/svgProps.ts
+++ b/src/components/RatingsBadge/svgProps.ts
@@ -19,14 +19,14 @@ export const svgProps = {
   },
   integer: {
     fontSize: 16,
-    fontWeight: 500,
+    fontWeight: 700,
     dominantBaseline: 'middle',
     textAnchor: 'middle',
   },
   decimal: {
     dominantBaseline: 'middle',
     textAnchor: 'middle',
-    fontWeight: 500,
+    fontWeight: 700,
     fontSize: 12,
     dy: -3,
   },

--- a/src/components/RatingsBadge/svgProps.ts
+++ b/src/components/RatingsBadge/svgProps.ts
@@ -10,7 +10,7 @@ export const svgProps = {
   },
   text: {
     fontSize: 18,
-    fill: 'white',
+    fill: 'black',
     fontFamily: 'Source Sans 3',
     x: '50%',
     y: '50%',
@@ -18,14 +18,16 @@ export const svgProps = {
     textAnchor: 'middle',
   },
   integer: {
-    fontSize: 18,
+    fontSize: 16,
+    fontWeight: 500,
     dominantBaseline: 'middle',
     textAnchor: 'middle',
   },
   decimal: {
     dominantBaseline: 'middle',
     textAnchor: 'middle',
-    fontSize: 14,
+    fontWeight: 500,
+    fontSize: 12,
     dy: -3,
   },
 }

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -35,7 +35,7 @@ export default function ResourceCard({
           <a
             href={url}
             target="_blank"
-            className="h3 link-secondary mb-0 d-block"
+            className="fs-3 fw-semibold lh-1 mb-0 d-block"
           >
             {title}
           </a>

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -15,7 +15,7 @@ interface ISearchBar extends FormControlProps {
 /** Thin wrapper around Bootstrap's FormControl for consistent SearchBar style */
 export default function SearchBar({
   className,
-  borderColor = 'secondary',
+  borderColor = 'primary',
   ...props
 }: ISearchBar) {
   const classes = [

--- a/src/i18n/LocaleSwitcher.tsx
+++ b/src/i18n/LocaleSwitcher.tsx
@@ -25,7 +25,6 @@ const Button = ({ currentLang }: IButton) => {
   return (
     <button
       className="btn btn-default btn-sm"
-      key={currentLang}
       type="submit"
       onClick={() => i18n.changeLanguage(currentLang)}
       lang={currentLang}
@@ -45,7 +44,7 @@ export default function LocaleSwitcher() {
       aria-label={t('navigation.localeSwitcher.selectLanguage')}
     >
       {Object.keys(languages).map((lng) => (
-        <Button currentLang={lng} />
+        <Button key={`locale-switcher-${lng}`} currentLang={lng} />
       ))}
     </div>
   )

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -75,7 +75,6 @@ export default function AgentView() {
           </div>
           <Button
             className="w-100"
-            variant="secondary"
             onClick={() => {
               user && user.isConfirmed
                 ? setShowModal(true)

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -75,6 +75,7 @@ export default function AgentView() {
           </div>
           <Button
             className="w-100"
+            variant="secondary"
             onClick={() => {
               user && user.isConfirmed
                 ? setShowModal(true)

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -15,7 +15,7 @@ export default function Resources() {
     <div className="vertical-rhythm">
       <h2 className="mb-2">Resources</h2>
       <a
-        className="btn btn-outline-secondary mb-4"
+        className="btn btn-primary mb-4"
         href="https://airtable.com/shrPJ7SKahULdzcMj"
         target="_blank"
       >

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -70,7 +70,7 @@ export default function Search() {
             <Link
               to="/agents/new"
               aria-label="Add an agent"
-              className="w-75 text-white btn btn-lg btn-primary"
+              className="w-75 btn btn-lg btn-primary"
             >
               Add an agent
             </Link>

--- a/src/pages/Vote.tsx
+++ b/src/pages/Vote.tsx
@@ -13,7 +13,7 @@ export default function Vote() {
     <BasicPage title={'Voting rights restored in California'} icon={icon}>
       <div className="w-100 text-center mb-4">
         <a
-          className="btn btn-primary btn-lg text-white"
+          className="btn btn-primary btn-lg"
           href="https://registertovote.ca.gov/"
         >
           Register to vote

--- a/src/styles/bootstrap-theme/colors.scss
+++ b/src/styles/bootstrap-theme/colors.scss
@@ -7,11 +7,11 @@ $propro-gray-3: #606060;
 $propro-gray-4: #444444;
 $propro-gray-5: #2b2b2b;
 
-$propro-orange-1: #f06748;
-$propro-orange-2: #f88737;
-$propro-orange-3: #f88b35;
-$propro-orange-4: #fc9b2d;
-$propro-orange-5: #ffa727;
+$propro-orange-1: #cb3311;
+$propro-orange-2: #f06748;
+$propro-orange-3: #f88737;
+$propro-orange-4: #ffa727;
+$propro-orange-5: #ffc775;
 $propro-green: #61d345;
 $propro-red: #c7272b;
 $propro-light: #f0f0f0;
@@ -24,7 +24,7 @@ $rating-4: $propro-orange-4;
 $rating-5: $propro-orange-5;
 
 // Theme colors
-$primary: $propro-orange-5;
+$primary: $propro-orange-4;
 $secondary: $propro-orange-1;
 $tertiary: $propro-gray-3;
 $success: $propro-green;
@@ -32,8 +32,6 @@ $danger: $propro-red;
 $warning: $propro-orange-5;
 $dark: $propro-gray-5;
 $light: $propro-gray-1;
-
-$min-contrast-ratio: 3;
 
 $custom-colors: (
   'brand': $secondary,
@@ -56,3 +54,5 @@ $enable-shadows: true;
 // Placeholder
 $placeholder-opacity-max: 0.12;
 $placeholder-opacity-min: 0.08;
+
+$link-color: $secondary;

--- a/src/styles/bootstrap-theme/colors.scss
+++ b/src/styles/bootstrap-theme/colors.scss
@@ -6,7 +6,6 @@ $propro-gray-2: #c9c9c9;
 $propro-gray-3: #606060;
 $propro-gray-4: #444444;
 $propro-gray-5: #2b2b2b;
-
 $propro-orange-1: #cb3311;
 $propro-orange-2: #f06748;
 $propro-orange-3: #f88737;
@@ -55,4 +54,9 @@ $enable-shadows: true;
 $placeholder-opacity-max: 0.12;
 $placeholder-opacity-min: 0.08;
 
+// Links and Navs
 $link-color: $secondary;
+
+$navbar-light-hover-color: rgba($secondary, 0.8);
+$navbar-light-active-color: rgba($secondary, 1);
+$navbar-light-disabled-color: rgba($secondary, 0.3);

--- a/src/styles/bootstrap-theme/fonts.scss
+++ b/src/styles/bootstrap-theme/fonts.scss
@@ -4,6 +4,10 @@ $font-family-sans-serif: 'Source Sans 3';
 
 $headings-font-weight: 600;
 
+.fw-semibold {
+  font-weight: 600;
+}
+
 // So far, there are only two header sizes in the designs:
 $h3-font-size: 1rem * 1.25 !default;
 $h4-font-size: 1rem * 1.125 !default;

--- a/src/styles/links.scss
+++ b/src/styles/links.scss
@@ -1,7 +1,7 @@
 .navbar,
 .navbar-nav {
   a.nav-link.active {
-    color: $orange;
+    color: $secondary;
   }
 }
 

--- a/src/styles/links.scss
+++ b/src/styles/links.scss
@@ -1,9 +1,9 @@
-.navbar,
-.navbar-nav {
-  a.nav-link.active {
-    color: $secondary;
-  }
-}
+// .navbar,
+// .navbar-nav {
+//   a.nav-link.active {
+//     color: $secondary;
+//   }
+// }
 
 a.card {
   text-decoration: none;

--- a/src/styles/links.scss
+++ b/src/styles/links.scss
@@ -1,10 +1,3 @@
-// .navbar,
-// .navbar-nav {
-//   a.nav-link.active {
-//     color: $secondary;
-//   }
-// }
-
 a.card {
   text-decoration: none;
 }

--- a/src/util/renderRichText.tsx
+++ b/src/util/renderRichText.tsx
@@ -8,7 +8,7 @@ const options: Options = {
   renderNode: {
     [BLOCKS.QUOTE]: (_, children) => (
       <blockquote className="blockquote text-center my-5 fw-bold">
-        <p>{children}</p>
+        {children}
       </blockquote>
     ),
   },


### PR DESCRIPTION
Description
---
1. Updates bootstrap variables, particularly primary and secondary colors.
2. Updates usage of bootstrap color utilities throughout to address contrast issues from design audit.
3. Fixes a few console warnings in LocaleSwitcher (keys) and renderRichText (nested <p> tags).

Screenshots
---
Example showing new link color in content:
<img width="500" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/8056b08c-af39-41e6-845d-8fea04414f80">
Resources page:
<img width="500" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/c5d02e9f-e122-453c-9bfb-8a5d75116190">


Fixes PRO-187, PRO-188, PRO-189