### PR TITLE
[PRO-192] Add Storybook translation support

### DIFF
--- a/.storybook/i18next.ts
+++ b/.storybook/i18next.ts
@@ -3,32 +3,13 @@ import i18n from 'i18next';
 import Backend from 'i18next-http-backend';
 import LanguageDetector from 'i18next-browser-languagedetector';
 
-const ns = ['common'];
-const supportedLngs = ['en', 'es'];
-const resources = ns.reduce((acc, n) => {
-    supportedLngs.forEach((lng) => {
-    if (!acc[lng]) acc[lng] = {};
-        acc[lng] = {
-            ...acc[lng],
-            [n]: require(`../public/locales/${lng}/translation.json`),
-        };
-    });
-    return acc;
-}, {});
-
 i18n.use(initReactI18next)
     .use(LanguageDetector)
     .use(Backend)
     .init({
-        //debug: true,
         lng: 'en',
         fallbackLng: 'en',
-        defaultNS: 'common',
-        ns,
-        interpolation: {escapeValue: false},
-        react: {useSuspense: false},
-        supportedLngs,
-        resources,
+        supportedLngs: ['en', 'es'],
     });
 
 export default i18n;

--- a/.storybook/i18next.ts
+++ b/.storybook/i18next.ts
@@ -1,0 +1,34 @@
+import {initReactI18next} from 'react-i18next';
+import i18n from 'i18next';
+import Backend from 'i18next-http-backend';
+import LanguageDetector from 'i18next-browser-languagedetector';
+
+const ns = ['common'];
+const supportedLngs = ['en', 'es'];
+const resources = ns.reduce((acc, n) => {
+    supportedLngs.forEach((lng) => {
+    if (!acc[lng]) acc[lng] = {};
+        acc[lng] = {
+            ...acc[lng],
+            [n]: require(`../public/locales/${lng}/translation.json`),
+        };
+    });
+    return acc;
+}, {});
+
+i18n.use(initReactI18next)
+    .use(LanguageDetector)
+    .use(Backend)
+    .init({
+        //debug: true,
+        lng: 'en',
+        fallbackLng: 'en',
+        defaultNS: 'common',
+        ns,
+        interpolation: {escapeValue: false},
+        react: {useSuspense: false},
+        supportedLngs,
+        resources,
+    });
+
+export default i18n;

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -6,6 +6,7 @@ const config: StorybookConfig = {
     "@storybook/addon-links",
     "@storybook/addon-essentials",
     "@storybook/addon-interactions",
+    'storybook-react-i18next',
   ],
   framework: {
     name: "@storybook/react-vite",

--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -15,5 +15,6 @@ const config: StorybookConfig = {
   docs: {
     autodocs: "tag",
   },
+  staticDirs: ['../public']
 }
 export default config

--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -1,8 +1,17 @@
+import i18n from './i18next';
 import type { Preview } from "@storybook/react"
 import "../src/styles/index.scss"
 
 const preview: Preview = {
+  globals: {
+    locale: 'en',
+    locales: {
+        en: 'English',
+        es: 'Español',
+    },
+  },
   parameters: {
+    i18n,
     actions: { argTypesRegex: "^on[A-Z].*" },
     controls: {
       matchers: {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "jsdom": "^22.1.0",
     "prettier": "^3.0.2",
     "storybook": "^7.4.0",
+    "storybook-react-i18next": "^2.0.9",
     "typescript": "^5.0.2",
     "vite": "^4.4.5",
     "vite-plugin-pwa": "^0.16.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -142,6 +142,9 @@ devDependencies:
   storybook:
     specifier: ^7.4.0
     version: 7.4.0
+  storybook-react-i18next:
+    specifier: ^2.0.9
+    version: 2.0.9(@storybook/components@7.4.0)(@storybook/manager-api@7.4.0)(@storybook/preview-api@7.4.0)(@storybook/types@7.4.0)(i18next-browser-languagedetector@7.1.0)(i18next-http-backend@2.3.1)(i18next@23.6.0)(react-dom@18.2.0)(react-i18next@13.3.1)(react@18.2.0)
   typescript:
     specifier: ^5.0.2
     version: 5.0.2
@@ -5258,7 +5261,6 @@ packages:
       node-fetch: 2.6.12
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
@@ -6559,7 +6561,6 @@ packages:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
     dependencies:
       void-elements: 3.1.0
-    dev: false
 
   /html-tags@3.3.1:
     resolution: {integrity: sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==}
@@ -6617,7 +6618,6 @@ packages:
     resolution: {integrity: sha512-cr2k7u1XJJ4HTOjM9GyOMtbOA47RtUoWRAtt52z43r3AoMs2StYKyjS3URPhzHaf+mn10hY9dZWamga5WPQjhA==}
     dependencies:
       '@babel/runtime': 7.22.10
-    dev: false
 
   /i18next-http-backend@2.3.1:
     resolution: {integrity: sha512-jnagFs5cnq4ryb+g92Hex4tB5kj3tWmiRWx8gHMCcE/PEgV1fjH5rC7xyJmPSgyb9r2xgcP8rvZxPKgsmvMqTw==}
@@ -6625,13 +6625,11 @@ packages:
       cross-fetch: 4.0.0
     transitivePeerDependencies:
       - encoding
-    dev: false
 
   /i18next@23.6.0:
     resolution: {integrity: sha512-z0Cxr0MGkt+kli306WS4nNNM++9cgt2b2VCMprY92j+AIab/oclgPxdwtTZVLP1zn5t5uo8M6uLsZmYrcjr3HA==}
     dependencies:
       '@babel/runtime': 7.22.10
-    dev: false
 
   /ico-endec@0.1.6:
     resolution: {integrity: sha512-ZdLU38ZoED3g1j3iEyzcQj+wAkY2xfWNkymszfJPoxucIUhK7NayQ+/C4Kv0nDFMIsbtbEHldv3V8PU494/ueQ==}
@@ -8394,7 +8392,6 @@ packages:
       i18next: 23.6.0
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
-    dev: false
 
   /react-inspector@6.0.2(react@18.2.0):
     resolution: {integrity: sha512-x+b7LxhmHXjHoU/VrFAzw5iutsILRoYyDq97EDYdFpPLcvqtEzk4ZSZSQjnFPbr5T57tLXnHcqFYoN1pI6u8uQ==}
@@ -9067,6 +9064,61 @@ packages:
 
   /store2@2.14.2:
     resolution: {integrity: sha512-siT1RiqlfQnGqgT/YzXVUNsom9S0H1OX+dpdGN1xkyYATo4I6sep5NmsRD/40s3IIOvlCq6akxkqG82urIZW1w==}
+    dev: true
+
+  /storybook-i18n@2.0.13(@storybook/components@7.4.0)(@storybook/manager-api@7.4.0)(@storybook/preview-api@7.4.0)(@storybook/types@7.4.0)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-p0VPL5QiHdeS3W9BvV7UnuTKw7Mj1HWLW67LK0EOoh5fpSQIchu7byfrUUe1RbCF1gT0gOOhdNuTSXMoVVoTDw==}
+    peerDependencies:
+      '@storybook/components': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
+      '@storybook/types': ^7.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/components': 7.4.0(@types/react-dom@18.2.7)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.4.0
+      '@storybook/types': 7.4.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    dev: true
+
+  /storybook-react-i18next@2.0.9(@storybook/components@7.4.0)(@storybook/manager-api@7.4.0)(@storybook/preview-api@7.4.0)(@storybook/types@7.4.0)(i18next-browser-languagedetector@7.1.0)(i18next-http-backend@2.3.1)(i18next@23.6.0)(react-dom@18.2.0)(react-i18next@13.3.1)(react@18.2.0):
+    resolution: {integrity: sha512-GFTOrYwOWShLqWNuTesPNhC79P3OHw1jkZ4gU3R50yTD2MUclF5DHLnuKeVfKZ323iV+I9fxLxuLIVHWVDJgXA==}
+    peerDependencies:
+      '@storybook/components': ^7.0.0
+      '@storybook/manager-api': ^7.0.0
+      '@storybook/preview-api': ^7.0.0
+      '@storybook/types': ^7.0.0
+      i18next: ^22.0.0 || ^23.0.0
+      i18next-browser-languagedetector: ^7.0.0
+      i18next-http-backend: ^2.0.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-i18next: ^12.0.0 || ^13.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-dom:
+        optional: true
+    dependencies:
+      '@storybook/components': 7.4.0(@types/react-dom@18.2.7)(@types/react@18.2.15)(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/manager-api': 7.4.0(react-dom@18.2.0)(react@18.2.0)
+      '@storybook/preview-api': 7.4.0
+      '@storybook/types': 7.4.0
+      i18next: 23.6.0
+      i18next-browser-languagedetector: 7.1.0
+      i18next-http-backend: 2.3.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+      react-i18next: 13.3.1(i18next@23.6.0)(react-dom@18.2.0)(react@18.2.0)
+      storybook-i18n: 2.0.13(@storybook/components@7.4.0)(@storybook/manager-api@7.4.0)(@storybook/preview-api@7.4.0)(@storybook/types@7.4.0)(react-dom@18.2.0)(react@18.2.0)
     dev: true
 
   /storybook@7.4.0:
@@ -10003,7 +10055,6 @@ packages:
   /void-elements@3.1.0:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /w3c-xmlserializer@4.0.0:
     resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,6 +1,8 @@
 {
   "agent": {
+    "agent": "Agente",
     "heading": "Agente: {{fullName}}",
+    "office": "Oficina",
     "rating_one": "{{count}} Opinión",
     "rating_other": "{{count}} Opiniónes"
   },

--- a/src/i18n/i18n.ts
+++ b/src/i18n/i18n.ts
@@ -3,8 +3,14 @@ import { initReactI18next } from 'react-i18next'
 import Backend from 'i18next-http-backend'
 import LanguageDetector from 'i18next-browser-languagedetector'
 
-i18n.use(Backend).use(LanguageDetector).use(initReactI18next).init({
-  fallbackLng: 'en',
-})
+i18n
+  .use(Backend)
+  .use(LanguageDetector)
+  .use(initReactI18next)
+  .init({
+    debug: true,
+    fallbackLng: 'en',
+    supportedLngs: ['en', 'es'],
+  })
 
 export default i18n


### PR DESCRIPTION
## What's New
Adds `storybook-react-i18next` as a dev dependency following [this guide](https://storybook.js.org/addons/storybook-react-i18next).

## How to Test
1. Run storybook locally. 
2. Click on the little globe icon in the top navigation to change your locale.
3. Check out the `AgentInfo` or `OfficeInfo` stories and notice that switching locales adjust translations on the cards. 