### PR TITLE
[PRO-183] Remove orange header on agent page

### DIFF
--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -54,9 +54,6 @@ export default function AgentView() {
         <i className="bi bi-chevron-left align-middle" />
         Back
       </a>
-      <h1 className="text-secondary mt-3">
-        {t('agent.heading', { fullName: agent.fullName })}
-      </h1>
       <Row className="mb-3">
         <Col xs={12} className="mb-3"></Col>
         <Col>


### PR DESCRIPTION
Removes orange header in `AgentView.tsx`.

**Before**:

![Image 11-26-23 at 4 01 PM](https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/daef2d40-3fcf-452f-a30e-76177439bc55)

**After**:

![Image 11-26-23 at 3 59 PM](https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/604c281b-1c67-4fc3-8b47-311dc0a760d2)
