### PR TITLE
[PRO-205] Make tags work with Es translations

### DIFF
--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -15,5 +15,31 @@
     "localeSwitcher": {
       "selectLanguage": "Elija su idioma"
     }
+  },
+  "ratings": {
+    "tags": {
+      "values": {
+        "communicative": "Communicativo",
+        "supportive": "Apoyante",
+        "aboveAndBeyond": "Demonstra esfuerzo",
+        "flexible": "Trabaja alrededor de mi horario",
+        "trustsMe": "Confia en mi",
+        "traumaInformed": "Trauma informado",
+        "unresponsive": "No responde",
+        "noResources": "No da accesso a recursos",
+        "notOnTime": "Lluega tarde",
+        "disrespectsHome": "Le falta respeto a mi hogar",
+        "disrespectsFamily": "Le falta respeto a mi familia",
+        "racist": "Racista",
+        "sexist": "Sexista",
+        "shortTempered": "Es de mal genio",
+        "inappropriateComments": "Commentario inapropiados",
+        "unpredictable": "Actitud impredecible",
+        "indifferent": "Es Indiferente",
+        "retaliatory": "Amenaza con represalias",
+        "unannouncedVisits": "Visita sin anunciar",
+        "communityOrgSupport": "Permite la participación con organizaciones comuni"
+      }
+    }
   }
 }

--- a/src/components/RateAgentModal/RateAgentTags.tsx
+++ b/src/components/RateAgentModal/RateAgentTags.tsx
@@ -1,7 +1,7 @@
 import { Control, Controller } from 'react-hook-form'
 import { useTranslation } from 'react-i18next'
 import { IRateAgentFormState } from './form-types'
-import { tagsTranslationMap } from './rateAgentUiStrings'
+import { TagKey, tagsTranslationMap } from './rateAgentUiStrings'
 import RateAgentTag from './RateAgentTag'
 
 interface IRateAgentTags {
@@ -11,7 +11,7 @@ interface IRateAgentTags {
 export default function RateAgentTags({ control }: IRateAgentTags) {
   const { t } = useTranslation()
 
-  const tagValues = Object.keys(tagsTranslationMap)
+  const tagValues = Object.keys(tagsTranslationMap) as TagKey[]
 
   return (
     <Controller
@@ -32,12 +32,12 @@ export default function RateAgentTags({ control }: IRateAgentTags) {
             <h4>
               {t('ratings.tags.title')} <small>(optional)</small>
             </h4>
-            {tagValues.map((t: string, i: number) => (
+            {tagValues.map((tagName: TagKey, i: number) => (
               <RateAgentTag
                 key={`rating-tag-btn-${i}`}
-                isActive={value.indexOf(t) > -1}
-                tagName={t}
-                onClick={() => handleClick(t)}
+                isActive={value.indexOf(tagName) > -1}
+                tagName={t(tagsTranslationMap[tagName])}
+                onClick={() => handleClick(tagName)}
               />
             ))}
           </div>

--- a/src/components/RateAgentModal/rateAgentUiStrings.ts
+++ b/src/components/RateAgentModal/rateAgentUiStrings.ts
@@ -1,4 +1,5 @@
-const I18NPATH = 'ratings.tags'
+const I18NPATH = 'ratings.tags.values'
+
 export const tagsTranslationMap = {
   Communicative: `${I18NPATH}.communicative`,
   Supportive: `${I18NPATH}.supportive`,
@@ -13,11 +14,13 @@ export const tagsTranslationMap = {
   'Disrespects my family': `${I18NPATH}.disrespectsFamily`,
   Racist: `${I18NPATH}.racist`,
   Sexist: `${I18NPATH}.sexist`,
-  'Short-tempered': `${I18NPATH}.short-tempered`,
+  'Short-tempered': `${I18NPATH}.shortTempered`,
   'Inappropriate comments': `${I18NPATH}.inappropriateComments`,
   'Unpredictable attitude': `${I18NPATH}.unpredictable`,
   Indifferent: `${I18NPATH}.indifferent`,
   'Threatens with retaliation': `${I18NPATH}.retaliatory`,
   'Unannounced visits': `${I18NPATH}.unannouncedVisits`,
   'Allows participation with community organizations': `${I18NPATH}.communityOrgSupport`,
-}
+} as const
+
+export type TagKey = keyof typeof tagsTranslationMap


### PR DESCRIPTION
## 🛠️ Changes
* Spanish translations for tags
* Tags can display localized string, and use english tag value regardless of current language setting

## 🧪 How To Test
* Sign in with a confirmed user (test@user.com)
* Enable Spanish language in the menu.
* Go to an agent and click the RATE button to open the rating modal.
* See translated tags in the tags section:
<img width="424" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/130b8daa-e738-487d-8141-97f86e33c9ff">
* Test that you can submit a review with tags successfully
