### PR TITLE
Use normalized rating data for overallStats

### DIFF
--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -23,13 +23,6 @@ export default function AgentView() {
   const { revalidate } = useRevalidator()
   const { t } = useTranslation()
 
-  const overallRatings: Rating[] = Object.entries(agent.overallStats).map(
-    (e) => {
-      const [label, value] = e
-      return { label, value }
-    },
-  )
-
   const closeModal = (refreshAgent = false) => {
     if (refreshAgent) {
       revalidate()
@@ -88,7 +81,7 @@ export default function AgentView() {
       </Row>
       <div className="mb-4">
         <div className="fw-normal mb-2 small">Overall Ratings</div>
-        {overallRatings.map((r: Rating, i: number) => (
+        {agent.overallStats.map((r: Rating, i: number) => (
           <RatingBar
             key={`overall-rating-${i}`}
             rating={r}

--- a/src/types/Agent.ts
+++ b/src/types/Agent.ts
@@ -1,4 +1,5 @@
 import Office from './Office'
+import { Rating } from './Review'
 import { Tag } from './Tag'
 
 type Agent = {
@@ -9,12 +10,12 @@ type Agent = {
   type: string
   id: string
   averageRating: number
-  overallStats?: { [key: string]: number }
+  overallStats?: Rating[]
   topTags?: Tag[]
 }
 
 export interface AgentDetail extends Agent {
-  overallStats: { [key: string]: number }
+  overallStats: Rating[]
   topTags: Tag[]
 }
 


### PR DESCRIPTION
### Changes
Remove code that was needed to massage `agent.overallStats` into the proper Rating shape, since the API will now return the proper `{ label:, value: }` shape.

Dependent on: https://github.com/ProjectProtocol/project-protocol-api/pull/114 and should be merged shortly after.

### Testing

This will break the Agent page until the rails PR is merged