### PR TITLE
[PRO-127] Add relevant Spanish translations, page titles

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -147,6 +147,11 @@
       "selectLanguage": "Select your language"
     }
   },
+  "pages": {
+    "about": "About",
+    "ethicalPrinciples": "Ethical principles",
+    "howDoesItWork": "How does it work?"
+  },
   "ratings": {
     "category": {
       "helpful": {

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -5,7 +5,7 @@
       "detail": "Password must be at least 8 characters long",
       "error": "Password change failed",
       "success": "Password changed",
-      "title": "Cange password"
+      "title": "Change password"
     },
     "confirmation": {
       "error": "Unable to verify account, please try again",
@@ -79,6 +79,7 @@
     "confirm": "Please confirm your account",
     "confirmationSent": "Confirmation sent",
     "confirmDetail": "We sent an email to {{email}} with confirmation instructions. Be sure to check your spam and junk folders",
+    "email": "Email",
     "forgotPassword": "Forgot password?",
     "newPassword": "New password",
     "resendCode": "Resend code",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -1,10 +1,73 @@
 {
+  "account": {
+    "changePassword": {
+      "action": "Cambiar",
+      "error": "Ha ocurrido un error",
+      "title": "Cambiar Contraseña"
+    },
+    "confirmation": {
+      "loading": "Cargando ..."
+    },
+    "create": {
+      "submit": "Enviar"
+    },
+    "delete": {
+      "form": {
+        "submit": "Eliminar tu cuenta"
+      },
+      "detail": "Eliminar tu cuenta",
+      "title": "Eliminar tu cuenta"
+    },
+    "login": {
+      "login": "Iniciar sesión",
+      "loginLabel": "Iniciar sesión",
+      "signup": "Registrarse"
+    },
+    "resetPassword": {
+      "modal": {
+        "heading": "El cambio de contraseña se realizó correctamente",
+        "intro": "Ingresa una nueva contraseña de al menos 8 caracteres.",
+        "newPassword": "Nueva contraseña",
+        "submit": "Cambiar tu contraseña",
+        "title": "Cambiar tu contraseña"
+      },
+      "newPasswordConfirm": {
+        "label": "Confirmar nueva contraseña"
+      },
+      "emailLabel": "Correo"
+    },
+    "confirm": "Confirmar tu cuenta",
+    "confirmDetail": "Hemos enviado un correo electrónico a {{email}} con las instrucciones de confirmación. Asegúrate de revisar tu bandeja de correo no deseado y spam.",
+    "email": "Correo",
+    "forgotPassword": "¿Olvidaste tu contraseña?",
+    "signUp": "Registrarse",
+    "title": "Configuración de la cuenta"
+  },
   "agent": {
+    "form": {
+      "office": "Oficina"
+    },
     "agent": "Agente",
+    "agents": "Agentes",
+    "back": "Atrás",
     "heading": "Agente: {{fullName}}",
     "office": "Oficina",
     "rating_one": "{{count}} Opinión",
     "rating_other": "{{count}} Opiniónes"
+  },
+  "contact": {
+    "email": "Correo:",
+    "title": "Contáctanos"
+  },
+  "error": {
+    "generic": "Ha ocurrido un error"
+  },
+  "footer": {
+    "about": "Acerca de",
+    "contact": "Contáctanos",
+    "ethicalPrinciples": "Principios éticos",
+    "howDoesItWork": "¿Como funciona?",
+    "tos": "Términos de servicio"
   },
   "navigation": {
     "account": "Cuenta",
@@ -15,5 +78,13 @@
     "localeSwitcher": {
       "selectLanguage": "Elija su idioma"
     }
+  },
+  "ratings": {
+    "submit": "Enviar"
+  },
+  "search": {
+    "mostRecent": "Calificaciones recientes",
+    "placeholder": "Buscar por agente u oficina",
+    "resultsDisplayed": "{{count}} de {{total}} calificaciones"
   }
 }

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -79,6 +79,11 @@
       "selectLanguage": "Elija su idioma"
     }
   },
+  "pages": {
+    "about": "Acerca de",
+    "ethicalPrinciples": "Principios éticos",
+    "howDoesItWork": "¿Como funciona?"
+  },
   "ratings": {
     "submit": "Enviar"
   },

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -88,7 +88,7 @@ export default function AccountView() {
           </>
         )}
         <AccountSettingsRow
-          title="Email"
+          title={t('account.email')}
           detail={user.email}
           action={
             <Button variant="outline-dark" size="sm" onClick={handleLogout}>

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -3,6 +3,7 @@ import {
   createBrowserRouter,
   createRoutesFromElements,
 } from 'react-router-dom'
+import { Translation } from 'react-i18next'
 import ErrorPage from './pages/ErrorPage.tsx'
 import Search from './pages/Search.tsx'
 import searchLoader from './loaders/searchLoader.ts'
@@ -47,17 +48,39 @@ const router = createBrowserRouter(
           <Route path="account" element={<Account />} />
           <Route
             path="about"
-            element={<ContentfulPage title="About" icon={icon} />}
+            element={
+              <Translation>
+                {(t) => <ContentfulPage title={t('pages.about')} icon={icon} />}
+              </Translation>
+            }
             loader={createStaticPageLoader('ABOUT_US')}
           />
           <Route
             path="how-does-it-work"
-            element={<ContentfulPage title="How does it work?" icon={help} />}
+            element={
+              <Translation>
+                {(t) => (
+                  <ContentfulPage
+                    title={t('pages.howDoesItWork')}
+                    icon={help}
+                  />
+                )}
+              </Translation>
+            }
             loader={createStaticPageLoader('HOW_DOES_IT_WORK')}
           />
           <Route
             path="ethical-principles"
-            element={<ContentfulPage title="Ethical principles" icon={icon} />}
+            element={
+              <Translation>
+                {(t) => (
+                  <ContentfulPage
+                    title={t('pages.ethicalPrinciples')}
+                    icon={icon}
+                  />
+                )}
+              </Translation>
+            }
             loader={createStaticPageLoader('ETHICAL_PRINCIPLES')}
           />
           <Route path="terms-of-service" element={<TermsOfService />} />


### PR DESCRIPTION
See commit messages for description. You can test in the app by toggling the locale between English and Spanish. It looks like your copy has changed a bit since the file that has the existing translation strings, but I did what was reasonable!