### PR TITLE
[PRO-195] Use new tags in resources page

### DIFF
--- a/src/components/Resources/CategoryPill.tsx
+++ b/src/components/Resources/CategoryPill.tsx
@@ -7,6 +7,7 @@ interface ICategoryPill {
   href?: string
   label: string
 }
+
 export default function CategoryPill({ active, label, href }: ICategoryPill) {
   return (
     <Badge

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -4,6 +4,7 @@ import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
 import { ResourceTagId, resourceTagLabelMap } from './resourceTagLabelMap'
 import { useRollbar } from '@rollbar/react'
+import { useEffect } from 'react'
 
 export default function ResourceCard({
   resource,
@@ -21,10 +22,9 @@ export default function ResourceCard({
     const label = resourceTagLabelMap[t.sys.id as ResourceTagId]
     if (!label) {
       rollbar.error('Unknown tag found on resource', {
-        resource,
+        tagId: t.sys.id,
       })
     }
-
     return label
   })
 

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -1,10 +1,8 @@
 import { ChainModifiers, Entry } from 'contentful'
-import {
-  ResourceCategoryType,
-  ResourceLinkSkeleton,
-} from 'src/types/contentful-types'
+import { ResourceLinkSkeleton } from 'src/types/contentful-types'
 import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
+import { ResourceTagId, resourceTagLabelMap } from './resourceTagLabelMap'
 
 export default function ResourceCard({
   resource,
@@ -16,9 +14,10 @@ export default function ResourceCard({
   const title = resource.fields.title as string
   const organization = resource.fields.organization as string
   const description = resource.fields.description as string
-  const category = (
-    resource.fields.category as string[]
-  )[0] as ResourceCategoryType
+
+  const tagLabels: string[] = resource.metadata.tags.map(
+    (t) => resourceTagLabelMap[t.sys.id as ResourceTagId],
+  )
 
   return (
     <Card body>
@@ -43,7 +42,15 @@ export default function ResourceCard({
         </div>
       </div>
       <p className="mb-3">{description ? description : organization}</p>
-      <CategoryPill active={true} label={category} />
+      <div className="d-flex flex-row flex-wrap gap-1">
+        {tagLabels.map((tagLabel: string) => (
+          <CategoryPill
+            key={`resource-${resource.sys.id}-${tagLabel}`}
+            active={true}
+            label={tagLabel}
+          />
+        ))}
+      </div>
     </Card>
   )
 }

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -4,7 +4,6 @@ import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
 import { ResourceTagId, resourceTagLabelMap } from './resourceTagLabelMap'
 import { useRollbar } from '@rollbar/react'
-import { useEffect } from 'react'
 
 export default function ResourceCard({
   resource,

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -17,15 +17,20 @@ export default function ResourceCard({
   const organization = resource.fields.organization as string
   const description = resource.fields.description as string
 
-  const tagLabels: string[] = resource.metadata.tags.map((t) => {
-    const label = resourceTagLabelMap[t.sys.id as ResourceTagId]
-    if (!label) {
-      rollbar.error('Unknown tag found on resource', {
-        tagId: t.sys.id,
-      })
-    }
-    return label
-  })
+  const tagLabels: { label: string; id: string }[] = resource.metadata.tags.map(
+    (t) => {
+      const label = resourceTagLabelMap[t.sys.id as ResourceTagId]
+      const id = t.sys.id
+
+      if (!label) {
+        rollbar.error('Unknown tag found on resource', {
+          tagId: t.sys.id,
+        })
+      }
+
+      return { label, id }
+    },
+  )
 
   return (
     <Card body>
@@ -51,11 +56,12 @@ export default function ResourceCard({
       </div>
       <p className="mb-3">{description ? description : organization}</p>
       <div className="d-flex flex-row flex-wrap gap-2">
-        {tagLabels.map((tagLabel: string) => (
+        {tagLabels.map(({ label, id }: { label: string; id: string }) => (
           <CategoryPill
-            key={`resource-${resource.sys.id}-${tagLabel}`}
+            key={`resource-${resource.sys.id}-${label}`}
+            href={`?category=${id}`}
             active={true}
-            label={tagLabel}
+            label={label}
           />
         ))}
       </div>

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -51,7 +51,7 @@ export default function ResourceCard({
         </div>
       </div>
       <p className="mb-3">{description ? description : organization}</p>
-      <div className="d-flex flex-row flex-wrap gap-1">
+      <div className="d-flex flex-row flex-wrap gap-2">
         {tagLabels.map((tagLabel: string) => (
           <CategoryPill
             key={`resource-${resource.sys.id}-${tagLabel}`}

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -3,6 +3,7 @@ import { ResourceLinkSkeleton } from 'src/types/contentful-types'
 import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
 import { ResourceTagId, resourceTagLabelMap } from './resourceTagLabelMap'
+import { useRollbar } from '@rollbar/react'
 
 export default function ResourceCard({
   resource,
@@ -10,14 +11,22 @@ export default function ResourceCard({
   resource: Entry<ResourceLinkSkeleton, ChainModifiers, string>
   index: number
 }) {
+  const rollbar = useRollbar()
   const url = resource.fields.url as string
   const title = resource.fields.title as string
   const organization = resource.fields.organization as string
   const description = resource.fields.description as string
 
-  const tagLabels: string[] = resource.metadata.tags.map(
-    (t) => resourceTagLabelMap[t.sys.id as ResourceTagId],
-  )
+  const tagLabels: string[] = resource.metadata.tags.map((t) => {
+    const label = resourceTagLabelMap[t.sys.id as ResourceTagId]
+    if (!label) {
+      rollbar.error('Unknown tag found on resource', {
+        resource,
+      })
+    }
+
+    return label
+  })
 
   return (
     <Card body>

--- a/src/components/Resources/ResourceFilters.tsx
+++ b/src/components/Resources/ResourceFilters.tsx
@@ -1,45 +1,25 @@
-import {
-  ResourceCategoryType,
-  resourceCategories,
-} from 'src/types/contentful-types'
 import CategoryPill from './CategoryPill'
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Collapse from 'react-bootstrap/Collapse'
+import { TagCollection, Tag } from 'contentful'
 
 interface IResourceFilters {
-  categories: ResourceCategoryType[]
+  currentFilters: string[] // current filters
+  tags: TagCollection
 }
 
-function buildCategoryHref(list: ResourceCategoryType[]) {
-  const p = new URLSearchParams(list.map((c) => ['category', c]))
-  return `?${p.toString()}`
-}
-
-function buildPillProps(
-  category: ResourceCategoryType,
-  categories: ResourceCategoryType[],
-) {
-  const active = categories.includes(category)
-  const href = active
-    ? buildCategoryHref(categories.filter((c) => c !== category))
-    : buildCategoryHref([...categories, category])
-
-  return {
-    active,
-    label: `${active ? '-' : '+'} ${category}`,
-    href,
-  }
-}
-
-export default function ResourceFilters({ categories }: IResourceFilters) {
+export default function ResourceFilters({
+  currentFilters,
+  tags,
+}: IResourceFilters) {
   const { t } = useTranslation()
-
   const [filtersOpen, setFiltersOpen] = useState(false)
   const filterToggleLabel = filtersOpen
     ? t('resources.filters.hide')
     : t('resources.filters.show')
+
   return (
     <div className="mb-4">
       <div className="d-flex flex-row align-items-center gap-2 mb-2">
@@ -57,14 +37,14 @@ export default function ResourceFilters({ categories }: IResourceFilters) {
       <Collapse in={filtersOpen}>
         <div id="resource-filters-container">
           <div className="d-flex flex-row flex-wrap gap-2">
-            {resourceCategories.map((c, i) => (
+            {tags.items.map((t: Tag, i: number) => (
               <div className="" key={`rfcp-${i}`}>
-                <CategoryPill {...buildPillProps(c, categories)} />
+                <CategoryPill {...buildPillProps(t, currentFilters)} />
               </div>
             ))}
-            {categories.length > 0 && (
+            {currentFilters.length > 0 && (
               <Link to="/resources" className="link-dark">
-                {t('resources.filters.clear', { count: categories.length })}
+                {t('resources.filters.clear', { count: currentFilters.length })}
               </Link>
             )}
           </div>
@@ -72,4 +52,30 @@ export default function ResourceFilters({ categories }: IResourceFilters) {
       </Collapse>
     </div>
   )
+}
+
+// Util
+function buildCategoryHref(list: string[]) {
+  const p = new URLSearchParams(list.map((c) => ['category', c]))
+  return `?${p.toString()}`
+}
+
+function buildPillProps(
+  tag: Tag,
+  currentFilters: string[], // current filters
+) {
+  const {
+    name,
+    sys: { id },
+  } = tag
+  const active = currentFilters.includes(id)
+  const href = active
+    ? buildCategoryHref(currentFilters.filter((c) => c !== id))
+    : buildCategoryHref([...currentFilters, id])
+
+  return {
+    active,
+    label: `${active ? '-' : '+'} ${name}`,
+    href,
+  }
 }

--- a/src/components/Resources/ResourceFilters.tsx
+++ b/src/components/Resources/ResourceFilters.tsx
@@ -1,6 +1,6 @@
 import CategoryPill from './CategoryPill'
-import { Link } from 'react-router-dom'
-import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
+import { useEffect, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import Collapse from 'react-bootstrap/Collapse'
 import { TagCollection, Tag } from 'contentful'
@@ -19,6 +19,12 @@ export default function ResourceFilters({
   const filterToggleLabel = filtersOpen
     ? t('resources.filters.hide')
     : t('resources.filters.show')
+
+  /* Reveal filters if a filter has been set via resource card tag */
+  const location = useLocation()
+  useEffect(() => {
+    if (currentFilters.length > 0) setFiltersOpen(true)
+  }, [location, currentFilters])
 
   return (
     <div className="mb-4">

--- a/src/components/Resources/ResourceFilters.tsx
+++ b/src/components/Resources/ResourceFilters.tsx
@@ -15,7 +15,7 @@ export default function ResourceFilters({
   tags,
 }: IResourceFilters) {
   const { t } = useTranslation()
-  const [filtersOpen, setFiltersOpen] = useState(false)
+  const [filtersOpen, setFiltersOpen] = useState(currentFilters.length > 0)
   const filterToggleLabel = filtersOpen
     ? t('resources.filters.hide')
     : t('resources.filters.show')

--- a/src/components/Resources/resourceTagLabelMap.ts
+++ b/src/components/Resources/resourceTagLabelMap.ts
@@ -1,0 +1,21 @@
+/**
+ * Maps contentful tag ID to name for display.
+ *
+ * This may need to be refreshed when updates are made to tags,
+ * for displaying.
+ */
+
+export const resourceTagLabelMap = {
+  resourceTypeJobTraining: 'Job training',
+  resourceTypeMentalHealthSupport: 'Mental health support',
+  resourceTypeEducation: 'Education',
+  resourceTypeLifeSkills: 'Life skills',
+  resourceTypeFamilyReunification: 'Family reunification',
+  resourceTypeHousing: 'Housing',
+  resourceTypeLegalHelp: 'Legal help',
+  resourceTypeReentryProgram: 'Reentry program',
+  resourceTypeAdvocacy: 'Advocacy',
+  resourceTypeIdentityBasedSupport: 'Identity-based support',
+} as const
+
+export type ResourceTagId = keyof typeof resourceTagLabelMap

--- a/src/loaders/resourcesLoader.ts
+++ b/src/loaders/resourcesLoader.ts
@@ -1,21 +1,24 @@
-import { EntryCollection } from 'contentful'
+import { EntryCollection, TagCollection } from 'contentful'
 import { LoaderFunctionArgs, defer } from 'react-router-dom'
-import {
-  ResourceCategoryType,
-  ResourceLinkSkeleton,
-} from 'src/types/contentful-types'
+import { ResourceLinkSkeleton } from 'src/types/contentful-types'
 import ContentfulClient from 'src/util/ContentfulClient'
 
 export type ResourcesLoaderReturn = {
   resourceCollection: Promise<EntryCollection<ResourceLinkSkeleton>>
-  categoryParam: ResourceCategoryType[]
+  categoryParam: string[]
+  allTags: TagCollection
 }
 
 export default async function ({ request }: LoaderFunctionArgs) {
   const url = new URL(request.url)
   const categoryParam = url.searchParams.getAll('category')
+  const allTags = await ContentfulClient.getTags()
+
   const cParam =
-    categoryParam.length > 0 ? { 'fields.category[in]': categoryParam } : {}
+    categoryParam.length > 0
+      ? { 'metadata.tags.sys.id[in]': categoryParam }
+      : {}
+
   const data = ContentfulClient.getEntries<ResourceLinkSkeleton>({
     content_type: 'resourceLink',
     ...cParam,
@@ -24,5 +27,6 @@ export default async function ({ request }: LoaderFunctionArgs) {
   return defer({
     resourceCollection: data,
     categoryParam,
+    allTags,
   })
 }

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -23,7 +23,10 @@ export default function Resources() {
       >
         {t('resources.suggestResource')}
       </a>
-      <ResourceFilters categories={data.categoryParam} />
+      <ResourceFilters
+        tags={data.allTags}
+        currentFilters={data.categoryParam}
+      />
       <div className="vertical-rhythm">
         <Suspense
           key={data.categoryParam.join('-')}

--- a/src/types/contentful-types.ts
+++ b/src/types/contentful-types.ts
@@ -17,23 +17,8 @@ export type Document<
   Locales extends LocaleCode,
 > = Entry<DocumentSkeleton, Modifiers, Locales>
 
-export const resourceCategories = [
-  'Articles',
-  'Education services',
-  'Housing services',
-  'Legal services',
-  'Mental health services',
-  'Resource databases',
-  'Service providers',
-  'Suggest a resource',
-  'Supportive services',
-] as const
-
-export type ResourceCategoryType = (typeof resourceCategories)[number]
-
 export interface ResourceLinkFields {
   title: EntryFieldTypes.Symbol
-  category: EntryFieldTypes.Array<EntryFieldTypes.Symbol<ResourceCategoryType>>
   location?: EntryFieldTypes.Symbol
   description?: EntryFieldTypes.Text
   url: EntryFieldTypes.Text

--- a/src/util/ContentfulClient.ts
+++ b/src/util/ContentfulClient.ts
@@ -14,6 +14,7 @@ const ContentfulClient = {
   },
   getEntry: client.getEntry,
   getEntries: client.getEntries,
+  getTags: client.getTags,
 }
 
 export default ContentfulClient


### PR DESCRIPTION
Changes
---
*Background*: @peiitforward was kind enough to tag all of our resources using Contentful's tagging system. These
changes dynamically load all defined tags to render the resource filters, and shows the relevant tags on the resource
cards.
- Load tag list from Contentful to render resource filters
- Show all relevant tags on ResourceCards
- Report unknown tags to rollbar. Show filters on page load if a category is selected


Testing
---
Have a click around the deploy preview and make sure all resource page functionality is working.

Screenshot
---
<img width="814" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/16cc741b-c23c-416b-8f4f-c5dc3a2faa21">

