### PR TITLE
Configure dev server - proxy /api localhost:3000

### DIFF
--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,7 +3,7 @@ import { snakeCase } from 'lodash'
 import transformKeys from 'src/util/transformKeys'
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: import.meta.env.VITE_API_URL || '/api',
   responseType: 'json',
   withCredentials: true,
   headers: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,4 +16,13 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['src/test/setup.ts'],
   },
+  server: {
+    proxy: {
+      '/api': {
+        target: 'http://localhost:3000',
+        changeOrigin: false,
+        rewrite: (path) => path.replace(/^\/api/, ''),
+      },
+    },
+  },
 })


### PR DESCRIPTION
This has a "sister" PR in the API repo: https://github.com/ProjectProtocol/project-protocol-api/pull/135

### Background:
This proxy configuration effectively lets the frontend and backend share the same domain, which makes browsers happier about cookies that get set. Instead of API calls going to `http://localhost:300`, they will go to the `/api` as if it were part of the same front-end application, e.g. `https://strictly-tough-bug.ngrok-free.app/api`.

This means that the auth cookie will be set with the domain `strictly-tough-bug.ngrok-free.app`, and the browser will better know to associate it with the front-end when the user navigates to it.

In production, we have the two domains `app.projectprotocol.org` and `api.projectprotocol.org`. I think we'll have to manually set the domain of the cookie for it to fully work in prod, but this branch at least will deliver expected behavior in development.

Changes
---
* Add proxy config to dev server.
* Rewrites `/api` requests to `http://localhost:300`, removing the `/api` namespace.
* Adds fallback baseURL `/api` -- this means no .env configuration will be strictly necessary for development if api is running locally.

Testing
---
* Pull this branch
* Pull the API branch for this PR https://github.com/ProjectProtocol/project-protocol-api/pull/135.
* Run client and API locally
* Comment out VITE_API_URL or set it to `/api`
* Check that the app has all expected functionality, populating data and allowing sign in/log out