### PR TITLE
Configuring redirect(proxy) for all Netlify environments

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,2 +1,3 @@
 [[plugins]]
   package = "netlify-plugin-redirect-env-placeholders"
+  source = 'public/_redirects'

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,3 +3,4 @@
   [plugins.inputs]
   source = '_redirects'
   base = 'public/'
+  

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[[plugins]]
+  package = "netlify-plugin-redirect-env-placeholders"

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,4 +1,5 @@
 [[plugins]]
   package = "netlify-plugin-redirect-env-placeholders"
   [plugins.inputs]
-  source = 'public/_redirects'
+  source = '_redirects'
+  base = 'public/'

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,4 @@
 [[plugins]]
   package = "netlify-plugin-redirect-env-placeholders"
+  [plugins.inputs]
   source = 'public/_redirects'

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "i18next-browser-languagedetector": "^7.1.0",
     "i18next-http-backend": "^2.3.1",
     "lodash": "^4.17.21",
+    "netlify-plugin-redirect-env-placeholders": "^0.1.0",
     "react": "^18.2.0",
     "react-bootstrap": "^2.8.0",
     "react-dom": "^18.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ dependencies:
   lodash:
     specifier: ^4.17.21
     version: 4.17.21
+  netlify-plugin-redirect-env-placeholders:
+    specifier: ^0.1.0
+    version: 0.1.0
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -7747,6 +7750,10 @@ packages:
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
     dev: true
+
+  /netlify-plugin-redirect-env-placeholders@0.1.0:
+    resolution: {integrity: sha512-JXnRVLS1nXawOEZeM8C+9vIhQq9YouzBt8nE6oFz875jrDkBVNM9Gfa88ZhHzCxHGBh6vi152EZ+8VN3whmAAQ==}
+    dev: false
 
   /node-abi@3.46.0:
     resolution: {integrity: sha512-LXvP3AqTIrtvH/jllXjkNVbYifpRbt9ThTtymSMSuHmhugQLAWr99QQFTm+ZRht9ziUvdGOgB+esme1C6iE6Lg==}

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/*        /index.html              200
 /api/*    https://project-protocol-staging.herokuapp.com/:splat   200
+/*        /index.html              200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,2 @@
-/api/*    https://project-protocol-staging.herokuapp.com/:splat   200
+/api/*    {{env:VITE_API_URL}}/:splat   200
 /*        /index.html              200

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,2 @@
-/*    /index.html   200
+/*        /index.html              200
+/api/*    https://project-protocol-staging.herokuapp.com/:splat   200

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -3,7 +3,7 @@ import { snakeCase } from 'lodash'
 import transformKeys from 'src/util/transformKeys'
 
 const apiClient = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || '/api',
+  baseURL: '/api',
   responseType: 'json',
   withCredentials: true,
   headers: {


### PR DESCRIPTION
Changes
---
Adds a plugin which replaces environment variables with their defined values in the _redirects file, for proxying API calls and nice auth cookies.

```
/api/*    {{env:VITE_API_URL}}/:splat   200
/*        /index.html              200
```
gets transformed to
```
/api/*    <<actual url from environment variable>>/:splat   200
/*        /index.html              200
```

Testing
---
To test, you can open the deploy preview and open the network tab in the inspector. You'll see that API calls now go to `/api` route and are successful.

Another test, and a main reason for this proxy, is if you log in, close and reopen the browser, and navigate back to the site, you should still be logged in, because the cookie is being set with the correct domain.