### PR TITLE
[PRO-233] User shouldnt be allowed to add agent without an account

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -252,10 +252,12 @@
   },
   "search": {
     "addAnAgent": "Add an agent",
+    "orLogIn": "or log in",
     "mostRecent": "Most recent reviews",
     "noResults": "Can't find what you're looking for?",
     "placeholder": "Search for a PO to rate",
-    "resultsDisplayed": "Showing {{count}} of {{total}} results"
+    "resultsDisplayed": "Showing {{count}} of {{total}} results",
+    "signUpToAddAgent": "Sign up to add an agent"
   },
   "tos": {
     "details": "Terms of Service",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -134,9 +134,13 @@
     "title": "Recursos"
   },
   "search": {
+    "addAnAgent": "Agregar agente",
+    "orLogIn": "o inicia sesión",
     "mostRecent": "Calificaciones recientes",
+    "noResults": "¿No encuentras lo que buscabas?",
     "placeholder": "Buscar por agente para calificar",
-    "resultsDisplayed": "{{count}} de {{total}} calificaciones"
+    "resultsDisplayed": "{{count}} de {{total}} calificaciones",
+    "signUpToAddAgent": "Registrarse para agregar agente"
   },
   "ui": {
     "submit": "Enviar",

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -1,0 +1,46 @@
+import Card from 'react-bootstrap/Card'
+import Button from 'react-bootstrap/Button'
+import { useTranslation } from 'react-i18next'
+import { Link } from 'react-router-dom'
+import { useLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
+import { useAuth } from 'src/contexts/auth/AuthContext'
+import { LOGIN_PAGES } from './LoginModal/constants'
+
+export default function AddAgentCard() {
+  const { t } = useTranslation()
+  const { user } = useAuth()
+  const { openLogin } = useLogin()
+
+  return (
+    <Card border="0" className="text-center mb-3">
+      <Card.Body className="p-4">
+        <h3 className="mb-4">{t('search.noResults')}</h3>
+        {!!user ? (
+          <Link
+            to="/agents/new"
+            aria-label={t('search.addAnAgent')}
+            className="w-75 btn btn-lg btn-primary"
+          >
+            {t('search.addAnAgent')}
+          </Link>
+        ) : (
+          <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
+            <Button
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
+              aria-label={t('search.signUpToAddAgent')}
+              className="w-75 btn btn-lg btn-primary d-block"
+            >
+              {t('search.signUpToAddAgent')}
+            </Button>
+            <Button
+              variant="link"
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
+            >
+              {t('search.orLogIn')}
+            </Button>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
+  )
+}

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -8,14 +8,14 @@ import { LOGIN_PAGES } from './LoginModal/constants'
 
 export default function AddAgentCard() {
   const { t } = useTranslation()
-  const { user } = useAuth()
+  const { isSignedIn } = useAuth()
   const { openLogin } = useLogin()
 
   return (
     <Card border="0" className="text-center mb-3">
       <Card.Body className="p-4">
         <h3 className="mb-4">{t('search.noResults')}</h3>
-        {!!user ? (
+        {isSignedIn ? (
           <Link
             to="/agents/new"
             aria-label={t('search.addAnAgent')}

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -17,9 +17,15 @@ import { useNavigate } from 'react-router-dom'
 interface LoginModal extends ModalProps {
   page: number
   setPage: (p: number) => void
+  handleRedirect: () => void
 }
 
-export default function LoginModal({ page, setPage, ...props }: LoginModal) {
+export default function LoginModal({
+  page,
+  setPage,
+  handleRedirect,
+  ...props
+}: LoginModal) {
   const { user, setUser } = useAuth()
   const { t } = useTranslation()
   const navigate = useNavigate()
@@ -29,6 +35,7 @@ export default function LoginModal({ page, setPage, ...props }: LoginModal) {
     if (user) {
       setUser(user)
       toast.success(t('account.login.success'))
+      handleRedirect()
     } else {
       toast.error(t('error.generic'))
     }

--- a/src/contexts/LoginUIProvider/LoginUIContext.ts
+++ b/src/contexts/LoginUIProvider/LoginUIContext.ts
@@ -3,7 +3,7 @@ import { createContext, useContext } from 'react'
 type LoginUIState = {
   loginOpen: boolean
   closeLogin: () => void
-  openLogin: (page: number) => void
+  openLogin: (page: number, postLoginPath?: string) => void
 }
 
 const LoginUIContext = createContext<LoginUIState | undefined>(undefined)

--- a/src/contexts/LoginUIProvider/index.tsx
+++ b/src/contexts/LoginUIProvider/index.tsx
@@ -3,6 +3,7 @@ import { LOGIN_PAGES } from 'src/components/LoginModal/constants'
 import { useAuth } from '../auth/AuthContext'
 import LoginModal from 'src/components/LoginModal'
 import { LoginUIContext } from './LoginUIContext'
+import { useNavigate } from 'react-router-dom'
 
 export default function LoginUIProvider({
   children,
@@ -12,12 +13,22 @@ export default function LoginUIProvider({
   const { user } = useAuth()
   const [loginOpen, setLoginOpen] = useState(!!user)
   const [loginPage, setLoginPage] = useState(LOGIN_PAGES.SIGN_IN)
+  const [redirectPath, setRedirectPath] = useState<string>('')
+  const navigate = useNavigate()
 
   const closeLogin = () => setLoginOpen(false)
 
-  const openLogin = (page: number) => {
+  const openLogin = (page: number, postLoginPath: string = '') => {
     setLoginPage(page)
     setLoginOpen(true)
+    if (postLoginPath) setRedirectPath(postLoginPath)
+  }
+
+  const handleRedirect = () => {
+    if (redirectPath !== '') {
+      navigate(redirectPath)
+      setRedirectPath('')
+    }
   }
 
   useEffect(() => {
@@ -37,6 +48,7 @@ export default function LoginUIProvider({
       <LoginModal
         setPage={setLoginPage}
         page={loginPage}
+        handleRedirect={handleRedirect}
         show={loginOpen}
         onHide={closeLogin}
       />

--- a/src/contexts/auth/AuthContext.ts
+++ b/src/contexts/auth/AuthContext.ts
@@ -3,6 +3,7 @@ import User from '../../types/User'
 
 type AuthProviderValue = {
   user?: User
+  isSignedIn: boolean
   setUser: (user?: User) => void
   handleLogout: () => void
   refreshUser: () => void

--- a/src/contexts/auth/AuthProvider.tsx
+++ b/src/contexts/auth/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 import { AuthContext } from './AuthContext'
 import User from '../../types/User'
 import { ApiSession } from 'src/api'
@@ -22,6 +22,8 @@ export default function AuthProvider({
     toast.success('Sign out successful!')
   }
 
+  const isSignedIn = useMemo(() => !!user, [user])
+
   async function refreshUser() {
     const { user } = await ApiSession.reauthenticate()
 
@@ -37,7 +39,14 @@ export default function AuthProvider({
     }
   }, [user, firstLoad])
 
-  const value = { user, setUser, authLoading, handleLogout, refreshUser }
+  const value = {
+    user,
+    setUser,
+    authLoading,
+    handleLogout,
+    isSignedIn,
+    refreshUser,
+  }
 
   return (
     <AuthContext.Provider value={value}>

--- a/src/pages/AgentNew.tsx
+++ b/src/pages/AgentNew.tsx
@@ -1,4 +1,4 @@
-import { useNavigate, Link } from 'react-router-dom'
+import { useNavigate, Link, Navigate } from 'react-router-dom'
 import { Button, FloatingLabel, Form } from 'react-bootstrap'
 import { useTranslation } from 'react-i18next'
 import officerIcon from '../images/officer-icon.svg'
@@ -10,6 +10,7 @@ import { debounce } from 'lodash'
 import { Controller, SubmitHandler, useForm } from 'react-hook-form'
 import SearchResult from 'src/components/SearchResult'
 import toast from 'react-hot-toast'
+import { useAuth } from 'src/contexts/auth/AuthContext'
 
 interface IAddAnAgentForm {
   firstName: string
@@ -19,9 +20,11 @@ interface IAddAnAgentForm {
 
 export default function AgentNew() {
   const navigate = useNavigate()
+  const { isSignedIn } = useAuth()
   const [showModal, setShowModal] = useState(false)
   const [offices, setOffices] = useState<Office[]>([])
   const [officeSearchText, setOfficeSearchText] = useState('')
+
   const {
     register,
     handleSubmit,
@@ -74,7 +77,9 @@ export default function AgentNew() {
     return () => handleSearchInput.cancel()
   }, [officeSearchText])
 
-  return (
+  return !isSignedIn ? (
+    <Navigate to="/" />
+  ) : (
     <div>
       <a role="button" onClick={() => navigate(-1)}>
         <i className="bi bi-chevron-left align-middle" />

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,19 +1,13 @@
-import {
-  Form,
-  useLoaderData,
-  useSubmit,
-  Link,
-  useNavigate,
-} from 'react-router-dom'
+import { Form, useLoaderData, useSubmit, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import SearchResult from '../components/SearchResult'
 import { useEffect } from 'react'
 import debounce from 'lodash/debounce'
-import { Card } from 'react-bootstrap'
 import { SearchLoaderReturn } from '../loaders/searchLoader'
 import SearchBar from 'src/components/SearchBar'
 import Agent from 'src/types/Agent'
 import Office from 'src/types/Office'
+import AddAgentCard from 'src/components/AddAgentCard'
 
 export default function Search() {
   const {
@@ -71,18 +65,7 @@ export default function Search() {
               onClick={handleResultClick(r)}
             />
           ))}
-        <Card border="0" className="text-center mb-3">
-          <Card.Body className="p-4">
-            <h3 className="mb-4">{t('search.noResults')}</h3>
-            <Link
-              to="/agents/new"
-              aria-label={t('search.addAnAgent')}
-              className="w-75 btn btn-lg btn-primary"
-            >
-              {t('search.addAnAgent')}
-            </Link>
-          </Card.Body>
-        </Card>
+        <AddAgentCard />
       </div>
     </div>
   )


### PR DESCRIPTION
Changes
---
* Factor out AddAgentCard
* Update locale strings and provide translations (using [this ms tool, worth a bookmark](https://msit.powerbi.com/view?r=eyJrIjoiMmE2NjJhMDMtNTY3MC00MmI2LWFmOWUtYWM5YTVjODI5MjQwIiwidCI6IjcyZjk4OGJmLTg2ZjEtNDFhZi05MWFiLTJkN2NkMDExZGI0NyIsImMiOjV9)
* Add a signed-out state to AddAgent card for opening sign up / log in modal.
* Add ability to specify a redirect after signing in.
* Add redirect to "/" if `agents/new` is visited without signing in
* Add `isSignedIn` state to AuthProvider for clearer checks

Testing
---
* Visit site (preview is fine)
* Scroll down or enter search to view the AddAgentCard at the bottom of the results.
* Toggle en/es language to see translations
* Log in or sign up via the provided buttons
* See that you are redirected to the add agent page
* Sign out and visit `/agents/new` to test the redirect to "/"