### PR TITLE
[PRO-246] Require confirmation to add agent

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -257,7 +257,8 @@
     "noResults": "Can't find what you're looking for?",
     "placeholder": "Search for a PO to rate",
     "resultsDisplayed": "Showing {{count}} of {{total}} results",
-    "signUpToAddAgent": "Sign up to add an agent"
+    "signUpToAddAgent": "Sign up to add an agent",
+    "confirmAccountToAddAgent": "Confirm your account to add an agent"
   },
   "tos": {
     "details": "Terms of Service",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -140,7 +140,8 @@
     "noResults": "¿No encuentras lo que buscabas?",
     "placeholder": "Buscar por agente para calificar",
     "resultsDisplayed": "{{count}} de {{total}} calificaciones",
-    "signUpToAddAgent": "Registrarse para agregar agente"
+    "signUpToAddAgent": "Registrarse para agregar agente",
+    "confirmAccountToAddAgent": "Confirmar tu cuenta para agregar agente"
   },
   "ui": {
     "submit": "Enviar",

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -45,7 +45,7 @@ export default function AddAgentCard({
               {t('search.signUpToAddAgent')}
             </Button>
             <Button
-              variant="link text-black"
+              variant="link"
               onClick={() => openLogin(LOGIN_PAGES.SIGN_IN)}
             >
               {t('search.orLogIn')}

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -1,66 +1,58 @@
 import Card from 'react-bootstrap/Card'
 import Button from 'react-bootstrap/Button'
 import { useTranslation } from 'react-i18next'
-import { useNavigate } from 'react-router-dom'
-import { useLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
-import { useAuth } from 'src/contexts/auth/AuthContext'
+import { NavigateFunction } from 'react-router-dom'
+import { OpenLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
 import { LOGIN_PAGES } from './LoginModal/constants'
-import { useState } from 'react'
-import ConfirmationModal from './ConfirmationModal'
+import User from 'src/types/User'
 
-export default function AddAgentCard() {
+interface IAddAgentCard {
+  openLogin: OpenLogin
+  user?: User
+  navigate: NavigateFunction
+  showConfirmModal: () => void
+}
+
+export default function AddAgentCard({
+  openLogin,
+  user,
+  navigate,
+  showConfirmModal,
+}: IAddAgentCard) {
   const { t } = useTranslation()
-  const navigate = useNavigate()
-  const { user } = useAuth()
-  const { openLogin } = useLogin()
-  const [showConfirmModal, setShowConfirmModal] = useState(false)
 
   return (
-    <>
-      <Card border="0" className="text-center mb-3">
-        <Card.Body className="p-4">
-          <h3 className="mb-4">{t('search.noResults')}</h3>
-          {user ? (
+    <Card border="0" className="text-center mb-3">
+      <Card.Body className="p-4">
+        <h3 className="mb-4">{t('search.noResults')}</h3>
+        {user ? (
+          <Button
+            onClick={() =>
+              user.isConfirmed ? navigate('/agents/new') : showConfirmModal()
+            }
+            aria-label={t('search.addAnAgent')}
+            className="w-75 btn btn-lg btn-primary"
+          >
+            {t('search.addAnAgent')}
+          </Button>
+        ) : (
+          <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
             <Button
-              onClick={() =>
-                user.isConfirmed
-                  ? navigate('/agents/new')
-                  : setShowConfirmModal(true)
-              }
-              aria-label={t('search.addAnAgent')}
-              className="w-75 btn btn-lg btn-primary"
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
+              aria-label={t('search.signUpToAddAgent')}
+              className="w-75 btn btn-lg btn-primary d-block"
             >
-              {t('search.addAnAgent')}
+              {t('search.signUpToAddAgent')}
             </Button>
-          ) : (
-            <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
-              <Button
-                onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
-                aria-label={t('search.signUpToAddAgent')}
-                className="w-75 btn btn-lg btn-primary d-block"
-              >
-                {t('search.signUpToAddAgent')}
-              </Button>
-              <Button
-                variant="link"
-                onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
-              >
-                {t('search.orLogIn')}
-              </Button>
-            </div>
-          )}
-        </Card.Body>
-      </Card>
-      {user && (
-        <ConfirmationModal
-          show={showConfirmModal}
-          onHide={() => setShowConfirmModal(false)}
-          title={t('search.confirmAccountToAddAgent')}
-          bodyClass="px-4"
-          user={user}
-          closeButton
-        />
-      )}
-    </>
+            <Button
+              variant="link"
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
+            >
+              {t('search.orLogIn')}
+            </Button>
+          </div>
+        )}
+      </Card.Body>
+    </Card>
   )
 }

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -1,46 +1,66 @@
 import Card from 'react-bootstrap/Card'
 import Button from 'react-bootstrap/Button'
 import { useTranslation } from 'react-i18next'
-import { Link } from 'react-router-dom'
+import { useNavigate } from 'react-router-dom'
 import { useLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
 import { useAuth } from 'src/contexts/auth/AuthContext'
 import { LOGIN_PAGES } from './LoginModal/constants'
+import { useState } from 'react'
+import ConfirmationModal from './ConfirmationModal'
 
 export default function AddAgentCard() {
   const { t } = useTranslation()
-  const { isSignedIn } = useAuth()
+  const navigate = useNavigate()
+  const { user } = useAuth()
   const { openLogin } = useLogin()
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
 
   return (
-    <Card border="0" className="text-center mb-3">
-      <Card.Body className="p-4">
-        <h3 className="mb-4">{t('search.noResults')}</h3>
-        {isSignedIn ? (
-          <Link
-            to="/agents/new"
-            aria-label={t('search.addAnAgent')}
-            className="w-75 btn btn-lg btn-primary"
-          >
-            {t('search.addAnAgent')}
-          </Link>
-        ) : (
-          <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
+    <>
+      <Card border="0" className="text-center mb-3">
+        <Card.Body className="p-4">
+          <h3 className="mb-4">{t('search.noResults')}</h3>
+          {user ? (
             <Button
-              onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
-              aria-label={t('search.signUpToAddAgent')}
-              className="w-75 btn btn-lg btn-primary d-block"
+              onClick={() =>
+                user.isConfirmed
+                  ? navigate('/agents/new')
+                  : setShowConfirmModal(true)
+              }
+              aria-label={t('search.addAnAgent')}
+              className="w-75 btn btn-lg btn-primary"
             >
-              {t('search.signUpToAddAgent')}
+              {t('search.addAnAgent')}
             </Button>
-            <Button
-              variant="link"
-              onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
-            >
-              {t('search.orLogIn')}
-            </Button>
-          </div>
-        )}
-      </Card.Body>
-    </Card>
+          ) : (
+            <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
+              <Button
+                onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
+                aria-label={t('search.signUpToAddAgent')}
+                className="w-75 btn btn-lg btn-primary d-block"
+              >
+                {t('search.signUpToAddAgent')}
+              </Button>
+              <Button
+                variant="link"
+                onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
+              >
+                {t('search.orLogIn')}
+              </Button>
+            </div>
+          )}
+        </Card.Body>
+      </Card>
+      {user && (
+        <ConfirmationModal
+          show={showConfirmModal}
+          onHide={() => setShowConfirmModal(false)}
+          title={t('search.confirmAccountToAddAgent')}
+          bodyClass="px-4"
+          user={user}
+          closeButton
+        />
+      )}
+    </>
   )
 }

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -38,7 +38,7 @@ export default function AddAgentCard({
         ) : (
           <div className="text-center w-100 d-flex flex-column justify-content-center align-items-center">
             <Button
-              onClick={() => openLogin(LOGIN_PAGES.SIGN_UP, '/agents/new')}
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_UP)}
               aria-label={t('search.signUpToAddAgent')}
               className="w-75 btn btn-lg btn-primary d-block"
             >
@@ -46,7 +46,7 @@ export default function AddAgentCard({
             </Button>
             <Button
               variant="link"
-              onClick={() => openLogin(LOGIN_PAGES.SIGN_IN, '/agents/new')}
+              onClick={() => openLogin(LOGIN_PAGES.SIGN_IN)}
             >
               {t('search.orLogIn')}
             </Button>

--- a/src/components/AddAgentCard.tsx
+++ b/src/components/AddAgentCard.tsx
@@ -45,7 +45,7 @@ export default function AddAgentCard({
               {t('search.signUpToAddAgent')}
             </Button>
             <Button
-              variant="link"
+              variant="link text-black"
               onClick={() => openLogin(LOGIN_PAGES.SIGN_IN)}
             >
               {t('search.orLogIn')}

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -47,7 +47,7 @@ export default function ConfirmationModal({
             <p>
               <a
                 role="button"
-                className="link"
+                className="link text-black"
                 onClick={requestConfirmationCode}
               >
                 {t('confirmationModal.resendLink')}
@@ -55,7 +55,9 @@ export default function ConfirmationModal({
             </p>
           )}
           <div className="text-center mt-5">
-            <Link to="/terms-of-service">{t('tos.title')}</Link>
+            <Link to="/terms-of-service" className="link text-black">
+              {t('tos.title')}
+            </Link>
           </div>
         </>
       )}

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -47,7 +47,7 @@ export default function ConfirmationModal({
             <p>
               <a
                 role="button"
-                className="link text-black"
+                className="link"
                 onClick={requestConfirmationCode}
               >
                 {t('confirmationModal.resendLink')}
@@ -55,7 +55,7 @@ export default function ConfirmationModal({
             </p>
           )}
           <div className="text-center mt-5">
-            <Link to="/terms-of-service" className="link text-black">
+            <Link to="/terms-of-service" className="link">
               {t('tos.title')}
             </Link>
           </div>

--- a/src/components/LoginModal/ForgotPasswordForm.tsx
+++ b/src/components/LoginModal/ForgotPasswordForm.tsx
@@ -76,7 +76,7 @@ export default function ForgotPasswordForm({
         {t('account.loginModal.loginHelper')}
         <a
           key={uniqueId()}
-          className="link text-black m-1"
+          className="link m-1"
           role="button"
           onClick={() => setPage(LOGIN_PAGES.SIGN_UP)}
         >

--- a/src/components/LoginModal/LoginForm.tsx
+++ b/src/components/LoginModal/LoginForm.tsx
@@ -97,7 +97,7 @@ export default function LoginForm({
           />
           <a
             key={uniqueId()}
-            className="link text-black"
+            className="link"
             role="button"
             onClick={() => setPage(LOGIN_PAGES.FORGOT_PASSWORD)}
           >
@@ -118,7 +118,7 @@ export default function LoginForm({
           {t('account.loginModal.loginHelper')}
           <a
             key={uniqueId()}
-            className="link text-black ms-1"
+            className="link ms-1"
             role="button"
             onClick={() => setPage(LOGIN_PAGES.SIGN_UP)}
           >

--- a/src/components/LoginModal/SignupForm.tsx
+++ b/src/components/LoginModal/SignupForm.tsx
@@ -110,7 +110,7 @@ export default function SignupForm({
             {t('account.loginModal.signupHelper')}
             <a
               key={uniqueId()}
-              className="link text-black ms-1"
+              className="link ms-1"
               role="button"
               onClick={() => setPage(LOGIN_PAGES.SIGN_IN)}
             >

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -148,7 +148,7 @@ export default function LoginModal({
             navigate('/terms-of-service')
             if (props.onHide) props.onHide()
           }}
-          className="link text-black"
+          className="link"
         >
           Read our terms of service
         </a>

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -47,7 +47,7 @@ export default function ResourceCard({
           <a
             href={url}
             target="_blank"
-            className="fs-3 fw-semibold lh-1 mb-0 d-block"
+            className="fs-3 fw-semibold lh-1 mb-0 d-block link-cobalt"
           >
             {title}
           </a>

--- a/src/components/ReviewCard/ReviewCardComment.tsx
+++ b/src/components/ReviewCard/ReviewCardComment.tsx
@@ -21,11 +21,7 @@ export default function ReviewCardComment({
           style={{ padding: '12px' }}
         >
           <span>{t('ratings.unpublishedCommentHeader')}</span>{' '}
-          <a
-            className="link text-black"
-            role="button"
-            onClick={showModerationModal}
-          >
+          <a className="link" role="button" onClick={showModerationModal}>
             {t('ratings.unpublishedCommentHeaderLink')}
           </a>
         </div>

--- a/src/contexts/LoginUIProvider/LoginUIContext.ts
+++ b/src/contexts/LoginUIProvider/LoginUIContext.ts
@@ -1,9 +1,11 @@
 import { createContext, useContext } from 'react'
 
+export type OpenLogin = (page: number, postLoginPath?: string) => void
+
 type LoginUIState = {
   loginOpen: boolean
   closeLogin: () => void
-  openLogin: (page: number, postLoginPath?: string) => void
+  openLogin: OpenLogin
 }
 
 const LoginUIContext = createContext<LoginUIState | undefined>(undefined)

--- a/src/pages/AgentNew.tsx
+++ b/src/pages/AgentNew.tsx
@@ -24,6 +24,7 @@ export default function AgentNew() {
   const [showModal, setShowModal] = useState(false)
   const [offices, setOffices] = useState<Office[]>([])
   const [officeSearchText, setOfficeSearchText] = useState('')
+  const { t } = useTranslation()
 
   const {
     register,
@@ -66,7 +67,6 @@ export default function AgentNew() {
     }
   }
 
-  const { t } = useTranslation()
   useEffect(() => {
     const handleSearchInput = debounce(getOffices, 500)
 
@@ -77,7 +77,7 @@ export default function AgentNew() {
     return () => handleSearchInput.cancel()
   }, [officeSearchText])
 
-  return !user || user.isConfirmed ? (
+  return !user || !user.isConfirmed ? (
     <Navigate to="/" />
   ) : (
     <div>

--- a/src/pages/AgentNew.tsx
+++ b/src/pages/AgentNew.tsx
@@ -20,7 +20,7 @@ interface IAddAnAgentForm {
 
 export default function AgentNew() {
   const navigate = useNavigate()
-  const { isSignedIn } = useAuth()
+  const { user } = useAuth()
   const [showModal, setShowModal] = useState(false)
   const [offices, setOffices] = useState<Office[]>([])
   const [officeSearchText, setOfficeSearchText] = useState('')
@@ -77,7 +77,7 @@ export default function AgentNew() {
     return () => handleSearchInput.cancel()
   }, [officeSearchText])
 
-  return !isSignedIn ? (
+  return !user || user.isConfirmed ? (
     <Navigate to="/" />
   ) : (
     <div>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -1,13 +1,16 @@
 import { Form, useLoaderData, useSubmit, useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
 import SearchResult from '../components/SearchResult'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import debounce from 'lodash/debounce'
 import { SearchLoaderReturn } from '../loaders/searchLoader'
 import SearchBar from 'src/components/SearchBar'
 import Agent from 'src/types/Agent'
 import Office from 'src/types/Office'
 import AddAgentCard from 'src/components/AddAgentCard'
+import { useAuth } from 'src/contexts/auth/AuthContext'
+import { useLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
+import ConfirmationModal from 'src/components/ConfirmationModal'
 
 export default function Search() {
   const {
@@ -17,6 +20,9 @@ export default function Search() {
   const submit = useSubmit()
   const navigate = useNavigate()
   const { t } = useTranslation()
+  const { user } = useAuth()
+  const { openLogin } = useLogin()
+  const [showConfirmModal, setShowConfirmModal] = useState(false)
 
   useEffect(() => {
     const searchEl = document.getElementById('search') as HTMLInputElement
@@ -65,7 +71,22 @@ export default function Search() {
               onClick={handleResultClick(r)}
             />
           ))}
-        <AddAgentCard />
+        <AddAgentCard
+          user={user}
+          openLogin={openLogin}
+          navigate={navigate}
+          showConfirmModal={() => setShowConfirmModal(true)}
+        />
+        {user && (
+          <ConfirmationModal
+            show={showConfirmModal}
+            onHide={() => setShowConfirmModal(false)}
+            title={t('search.confirmAccountToAddAgent')}
+            bodyClass="px-4"
+            user={user}
+            closeButton
+          />
+        )}
       </div>
     </div>
   )

--- a/src/styles/bootstrap-theme/colors.scss
+++ b/src/styles/bootstrap-theme/colors.scss
@@ -29,6 +29,7 @@ $info: $sea-green;
 
 $custom-colors: (
   'white': $white,
+  'cobalt': $cobalt,
   'loquat': $loquat,
   'meyer-lemon': $meyer-lemon,
   'medium-gray': $medium-gray,
@@ -52,7 +53,7 @@ $placeholder-opacity-max: 0.12;
 $placeholder-opacity-min: 0.08;
 
 // Links and Navs
-$link-color: $cobalt;
+$link-color: $body-color;
 
 $navbar-light-hover-color: rgba($primary, 1);
 $navbar-light-active-color: rgba($black, 1);

--- a/src/test/components/AddAgentCard.test.tsx
+++ b/src/test/components/AddAgentCard.test.tsx
@@ -1,0 +1,73 @@
+import { render, fireEvent } from '@testing-library/react'
+import AddAgentCard from 'src/components/AddAgentCard'
+import User from 'src/types/User'
+
+// Utility function to render the AddAgentCard
+const renderAddAgentCard = (user?: User) => {
+  const openLoginMock = vitest.fn()
+  const navigateMock = vitest.fn()
+  const showConfirmModalMock = vitest.fn()
+
+  return {
+    openLoginMock,
+    navigateMock,
+    showConfirmModalMock,
+    ...render(
+      <AddAgentCard
+        openLogin={openLoginMock}
+        user={user}
+        navigate={navigateMock}
+        showConfirmModal={showConfirmModalMock}
+      />,
+    ),
+  }
+}
+
+describe('AddAgentCard', () => {
+  it('renders correctly with user logged in and confirmed', () => {
+    const user = { isConfirmed: true } as User
+    const { getByText } = renderAddAgentCard(user)
+
+    // Check if the "Add an Agent" button is rendered
+    const addButton = getByText('search.addAnAgent')
+    expect(addButton).toBeInTheDocument()
+  })
+
+  it('opens confirmation modal when user logged in but not confirmed', () => {
+    const user = { isConfirmed: false } as User
+
+    const { getByText, showConfirmModalMock } = renderAddAgentCard(user)
+
+    // Click the "Add an Agent" button to trigger the modal
+    const addButton = getByText('search.addAnAgent')
+    fireEvent.click(addButton)
+
+    // Check if the confirmation modal is rendered after clicking the button
+    expect(showConfirmModalMock).toHaveBeenCalled()
+  })
+
+  it('renders correctly with user not logged in', () => {
+    const { getByText } = renderAddAgentCard()
+
+    // Check if the "Sign Up to Add Agent" button is rendered
+    const signUpButton = getByText('search.signUpToAddAgent')
+    expect(signUpButton).toBeInTheDocument()
+
+    // Check if the "or Log In" link is rendered
+    const logInLink = getByText('search.orLogIn')
+    expect(logInLink).toBeInTheDocument()
+  })
+
+  it('navigates to /agents/new when "Add an Agent" button is clicked and user is confirmed', () => {
+    const user = { isConfirmed: true } as User
+
+    const { getByText, navigateMock } = renderAddAgentCard(user)
+
+    // Click the "Add an Agent" button to trigger navigation
+    const addButton = getByText('search.addAnAgent')
+    fireEvent.click(addButton)
+
+    // Check if the navigate function is called with the correct path
+    expect(navigateMock).toHaveBeenCalledWith('/agents/new')
+  })
+})


### PR DESCRIPTION
Changes
---
* Add user.isConfirmed check. Show confirmation modal if unconfirmed.
* In `agents/new`, redirect unconfirmed users.
* Translations
* AddAgentCard.test.tsx

Testing
---
* Create or use an unconfirmed account, and click the button at the bottom of search results-- you should see the confirmation modal with an appropriate title.

<img width="510" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/82322c3c-ad26-4cad-8cc8-851f757d74b8">
