### PR TITLE
[PRO-247] Show indiciation in ui if user must wait to rate again

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -117,6 +117,7 @@
     "agent": "Agent",
     "agents": "Agents",
     "agentInfo": "Agent Info",
+    "averageRatingTitle": "Rating",
     "back": "Back",
     "formIntro": "Use this form to contribute a new agent listing to the Project Protocol database. After creation, you and others will be able to read and contribute to reviews about first hand experiences with this individual.",
     "heading": "Agent: {{fullName}}",
@@ -124,6 +125,8 @@
     "noResults": "No results found. Please try a different search.",
     "office": "Office",
     "officerIconAlt": "Officer icon",
+    "overallRatings": "Overall ratings",
+    "popularTags": "Popular tags",
     "rateAgent": "Rate agent",
     "rating_one": "{{count}} Rating",
     "rating_other": "{{count}} Ratings",
@@ -133,7 +136,8 @@
     "searchByOffice": "Search agents for this office",
     "searchOffices": "Search offices",
     "selectOffice": "Select an office",
-    "signUp": "Sign up to rate"
+    "signUp": "Sign up to rate",
+    "unrateable": "Please wait 24 hours to rate this agent again."
   },
   "contact": {
     "callOrText": "Call or text:",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -47,16 +47,20 @@
     "form": {
       "office": "Oficina"
     },
+    "averageRatingTitle": "Calificación",
     "agent": "Agente",
     "agents": "Agentes",
     "back": "Atrás",
     "heading": "Agente: {{fullName}}",
     "logIn": "o inicia sesión",
     "office": "Oficina",
+    "overallRatings": "Calificaciones generales",
+    "popularTags": "Etiquetas populares",
     "rateAgent": "Calificar",
     "rating_one": "{{count}} Opinión",
     "rating_other": "{{count}} Opiniónes",
-    "signUp": "Regístrate para calificar"
+    "signUp": "Regístrate para calificar",
+    "unrateable": "Por favor, espere 24 horas antes de volver a calificar a este agente."
   },
   "contact": {
     "email": "Correo:",
@@ -122,7 +126,8 @@
         "unannouncedVisits": "Visita sin anunciar",
         "communityOrgSupport": "Permite la participación con organizaciones comuni"
       }
-    }
+    },
+    "rating": "Calificación"
   },
   "resources": {
     "filters": {

--- a/src/components/Agent/RateAgentButton.tsx
+++ b/src/components/Agent/RateAgentButton.tsx
@@ -3,7 +3,7 @@ import User from 'src/types/User'
 import { LOGIN_PAGES } from '../LoginModal/constants'
 import { useTranslation } from 'react-i18next'
 
-interface IRateAgentButton {
+export interface IRateAgentButton {
   user?: User
   isRateable: boolean
   openLogin: (n: number) => void
@@ -44,7 +44,7 @@ export default function RateAgentButton({
       </Button>
       {hasRecentReviews && (
         <p className="my-1 text-dark small text-center">
-          Please wait 24 hours to rate this agent again.
+          {t('agent.unrateable')}
         </p>
       )}
       {!user && (

--- a/src/components/Agent/RateAgentButton.tsx
+++ b/src/components/Agent/RateAgentButton.tsx
@@ -5,15 +5,17 @@ import { useTranslation } from 'react-i18next'
 
 interface IRateAgentButton {
   user?: User
+  isRateable: boolean
+  openLogin: (n: number) => void
   showRatingModal: () => void
   showConfirmationModal: () => void
-  openLogin: (n: number) => void
 }
 export default function RateAgentButton({
   user,
+  isRateable,
+  openLogin,
   showRatingModal,
   showConfirmationModal,
-  openLogin,
 }: IRateAgentButton) {
   const { t } = useTranslation()
 
@@ -29,11 +31,22 @@ export default function RateAgentButton({
     }
   }
 
+  const hasRecentReviews = user && !isRateable
+
   return (
-    <>
-      <Button className="w-100" onClick={rateButtonOnClick}>
+    <div style={{ maxWidth: '150px' }}>
+      <Button
+        className="w-100"
+        onClick={rateButtonOnClick}
+        disabled={hasRecentReviews}
+      >
         {user ? t('agent.rateAgent') : t('agent.signUp')}
       </Button>
+      {hasRecentReviews && (
+        <p className="my-1 text-dark small text-center">
+          Please wait 24 hours to rate this agent again.
+        </p>
+      )}
       {!user && (
         <div className="text-center">
           <Button variant="link" onClick={() => openLogin(LOGIN_PAGES.SIGN_IN)}>
@@ -41,6 +54,6 @@ export default function RateAgentButton({
           </Button>
         </div>
       )}
-    </>
+    </div>
   )
 }

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -65,7 +65,7 @@ export default function AgentView() {
         </Col>
         <Col xs="auto" style={{ minWidth: 100 }}>
           <div className="position-relative mb-3 text-center">
-            <h4 className="mb-0">Rating</h4>
+            <h4 className="mb-0">{t('agent.averageRatingTitle')}</h4>
             <span className="h2 fw-bold m-0">{agent.averageRating}</span>
             <span
               className="fw-bold"
@@ -84,7 +84,7 @@ export default function AgentView() {
         </Col>
       </Row>
       <div className="mb-4">
-        <div className="fw-normal mb-2 small">Overall Ratings</div>
+        <div className="fw-normal mb-2 small">{t('agent.overallRatings')}</div>
         {agent.overallStats.map((r: Rating, i: number) => (
           <RatingBar
             key={`overall-rating-${i}`}
@@ -95,7 +95,7 @@ export default function AgentView() {
         ))}
       </div>
       <div className="mb-4">
-        <div className="fw-normal mb-2 small">Popular Tags</div>
+        <div className="fw-normal mb-2 small">{t('agent.popularTags')}</div>
         {agent.topTags.map((tag: Tag, i: number) => (
           <TagBadge
             label={t(tagsTranslationMap[tag.name])}

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -43,11 +43,7 @@ export default function AgentView() {
 
     if (reviewSuccess) {
       data.reviewInput && data.reviewInput.length > 0
-        ? toast(t('ratings.createdWithCommentSuccess'), {
-            icon: (
-              <i className="bi bi-exclamation-triangle-fill text-warning"></i>
-            ),
-          })
+        ? toast.success(t('ratings.createdWithCommentSuccess'))
         : toast.success(t('ratings.createdSuccess'))
 
       closeModal(true)
@@ -82,6 +78,7 @@ export default function AgentView() {
             openLogin={openLogin}
             showRatingModal={() => setShowRateAgentModal(true)}
             showConfirmationModal={() => setShowConfirmToRateModal(true)}
+            isRateable={!!agent.isRateable}
             user={user}
           />
         </Col>

--- a/src/test/components/Agent/RateAgentButton.test.tsx
+++ b/src/test/components/Agent/RateAgentButton.test.tsx
@@ -1,5 +1,7 @@
 import { render, fireEvent } from '@testing-library/react'
-import RateAgentButton from 'src/components/Agent/RateAgentButton'
+import RateAgentButton, {
+  IRateAgentButton,
+} from 'src/components/Agent/RateAgentButton'
 import { LOGIN_PAGES } from 'src/components/LoginModal/constants'
 import User from 'src/types/User'
 
@@ -16,53 +18,38 @@ describe('RateAgentButton button behavior', () => {
     isConfirmed: false,
   } as User
 
+  const defaultProps = {
+    user: mockUser,
+    showRatingModal: mockShowRatingModal,
+    showConfirmationModal: mockShowConfirmationModal,
+    openLogin: mockOpenLogin,
+    isRateable: true,
+  }
+
+  const renderButton = (props: IRateAgentButton = defaultProps) =>
+    render(<RateAgentButton {...props} />)
+
   it("shows 'Rate agent' when user is signed in", () => {
-    const { getByText } = render(
-      <RateAgentButton
-        user={mockUser}
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton()
 
     expect(getByText('agent.rateAgent')).toBeTruthy()
   })
 
   it("shows 'Sign up to rate' when user is not signed in", () => {
-    const { getByText } = render(
-      <RateAgentButton
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton({ ...defaultProps, user: undefined })
 
     expect(getByText('agent.signUp')).toBeTruthy()
   })
 
   it("shows 'Sign up to rate' and 'log in' link when user is not signed in", () => {
-    const { getByText } = render(
-      <RateAgentButton
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton({ ...defaultProps, user: undefined })
 
     expect(getByText('agent.signUp')).toBeTruthy()
     expect(getByText('agent.logIn')).toBeTruthy()
   })
 
   it('calls showRatingModal when user is confirmed', async () => {
-    const { getByText } = render(
-      <RateAgentButton
-        user={mockUser}
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton()
 
     await fireEvent.click(getByText('agent.rateAgent'))
     expect(mockShowRatingModal).toHaveBeenCalled()
@@ -71,14 +58,10 @@ describe('RateAgentButton button behavior', () => {
   })
 
   it('calls showConfirmationModal when user is not confirmed', async () => {
-    const { getByText } = render(
-      <RateAgentButton
-        user={mockUnconfirmedUser}
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton({
+      ...defaultProps,
+      user: mockUnconfirmedUser,
+    })
 
     fireEvent.click(getByText('agent.rateAgent'))
     expect(mockShowRatingModal).not.toHaveBeenCalled()
@@ -87,13 +70,7 @@ describe('RateAgentButton button behavior', () => {
   })
 
   it('calls openLogin with SIGN_UP when not signed in', async () => {
-    const { getByText } = render(
-      <RateAgentButton
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton({ ...defaultProps, user: undefined })
 
     fireEvent.click(getByText('agent.signUp'))
     expect(mockShowRatingModal).not.toHaveBeenCalled()
@@ -102,17 +79,22 @@ describe('RateAgentButton button behavior', () => {
   })
 
   it('calls openLogin with SIGN_IN when "or log in" link is clicked', async () => {
-    const { getByText } = render(
-      <RateAgentButton
-        showRatingModal={mockShowRatingModal}
-        showConfirmationModal={mockShowConfirmationModal}
-        openLogin={mockOpenLogin}
-      />,
-    )
+    const { getByText } = renderButton({ ...defaultProps, user: undefined })
 
     fireEvent.click(getByText('agent.logIn'))
     expect(mockShowRatingModal).not.toHaveBeenCalled()
     expect(mockShowConfirmationModal).not.toHaveBeenCalled()
     expect(mockOpenLogin).toHaveBeenCalledWith(LOGIN_PAGES.SIGN_IN)
+  })
+
+  it('disables rate button if agent is not rateable for current user', () => {
+    const { getByText } = renderButton({ ...defaultProps, isRateable: false })
+    const button = getByText('agent.rateAgent')
+    expect(button).toBeDisabled()
+  })
+
+  it('shows help text if agent is not rateable for current user', () => {
+    const { queryByText } = renderButton({ ...defaultProps, isRateable: false })
+    expect(queryByText('agent.unrateable')).toBeInTheDocument()
   })
 })

--- a/src/types/Agent.ts
+++ b/src/types/Agent.ts
@@ -12,6 +12,7 @@ type Agent = {
   averageRating: number
   overallStats?: Rating[]
   topTags?: Tag[]
+  isRateable?: boolean
 }
 
 export interface AgentDetail extends Agent {


### PR DESCRIPTION
Changes
---
- Use agent.isRateable to disable rate button and show help text
- Test and more translations

Testing
---
Depends on https://github.com/ProjectProtocol/project-protocol-api/pull/138.

- Log in as confirmed user, and rate an agent.
- After posting a rating, see that the rate button is disabled with a helpful message.

<img width="628" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/721aab55-72e2-46c9-9c2f-e9e15d21d106">
