### PR TITLE
[PRO-250] [Bug] After signing in while viewing an agent, rate button is disabled

### DIFF
--- a/src/components/Agent/RateAgentButton.tsx
+++ b/src/components/Agent/RateAgentButton.tsx
@@ -2,25 +2,42 @@ import { Button } from 'react-bootstrap'
 import User from 'src/types/User'
 import { LOGIN_PAGES } from '../LoginModal/constants'
 import { useTranslation } from 'react-i18next'
+import { OpenLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
+import AsyncButton from '../AsyncButton'
+import toast from 'react-hot-toast'
 
 export interface IRateAgentButton {
   user?: User
   isRateable: boolean
-  openLogin: (n: number) => void
+  openLogin: OpenLogin
+  isLoading: boolean
+  revalidate: () => void
   showRatingModal: () => void
   showConfirmationModal: () => void
 }
 export default function RateAgentButton({
   user,
+  isLoading,
   isRateable,
   openLogin,
+  revalidate,
   showRatingModal,
   showConfirmationModal,
 }: IRateAgentButton) {
   const { t } = useTranslation()
 
+  const hasRecentReviews = user && !isRateable
+
   const rateButtonOnClick = () => {
     if (user) {
+      if (user.isConfirmed && hasRecentReviews) {
+        return toast(t('agent.unrateable'), {
+          icon: 'ℹ️',
+          id: `agent-unrateable-toast`,
+          duration: 3000,
+        })
+      }
+
       if (user.isConfirmed) {
         showRatingModal()
       } else {
@@ -31,25 +48,25 @@ export default function RateAgentButton({
     }
   }
 
-  const hasRecentReviews = user && !isRateable
-
   return (
-    <div style={{ maxWidth: '150px' }}>
-      <Button
+    <div>
+      <AsyncButton
         className="w-100"
         onClick={rateButtonOnClick}
-        disabled={hasRecentReviews}
+        loading={isLoading}
       >
         {user ? t('agent.rateAgent') : t('agent.signUp')}
-      </Button>
-      {hasRecentReviews && (
-        <p className="my-1 text-dark small text-center">
-          {t('agent.unrateable')}
-        </p>
-      )}
+      </AsyncButton>
       {!user && (
         <div className="text-center">
-          <Button variant="link" onClick={() => openLogin(LOGIN_PAGES.SIGN_IN)}>
+          <Button
+            variant="link"
+            onClick={() =>
+              openLogin(LOGIN_PAGES.SIGN_IN, {
+                callback: revalidate,
+              })
+            }
+          >
             {t('agent.logIn')}
           </Button>
         </div>

--- a/src/components/AsyncButton.tsx
+++ b/src/components/AsyncButton.tsx
@@ -17,9 +17,9 @@ export default function AsyncButton({
           <Spinner
             size="sm"
             role="status"
+            className="align-middle"
             animation="border"
             variant="black"
-            className="mt-2"
           />
         </>
       ) : (

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -17,13 +17,13 @@ import { useNavigate } from 'react-router-dom'
 interface LoginModal extends ModalProps {
   page: number
   setPage: (p: number) => void
-  handleRedirect: () => void
+  postLogin: () => void
 }
 
 export default function LoginModal({
   page,
   setPage,
-  handleRedirect,
+  postLogin,
   ...props
 }: LoginModal) {
   const { user, setUser } = useAuth()
@@ -35,7 +35,7 @@ export default function LoginModal({
     if (user) {
       setUser(user)
       toast.success(t('account.login.success'))
-      handleRedirect()
+      postLogin()
     } else {
       toast.error(t('error.generic'))
     }

--- a/src/contexts/LoginUIProvider/LoginUIContext.ts
+++ b/src/contexts/LoginUIProvider/LoginUIContext.ts
@@ -1,6 +1,10 @@
 import { createContext, useContext } from 'react'
 
-export type OpenLogin = (page: number, postLoginPath?: string) => void
+export type OpenLoginOptions = {
+  callback?: () => void
+}
+
+export type OpenLogin = (page: number, options?: OpenLoginOptions) => void
 
 type LoginUIState = {
   loginOpen: boolean

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -26,14 +26,14 @@ export default function AgentView() {
   const [showRateAgentModal, setShowRateAgentModal] = useState(false)
   const [showModerationModal, setShowModerationModal] = useState(false)
   const navigate = useNavigate()
-  const { revalidate } = useRevalidator()
+  const revalidator = useRevalidator()
   const { t } = useTranslation()
 
   const [showConfirmToRateModal, setShowConfirmToRateModal] = useState(false)
 
   const closeModal = (refreshAgent = false) => {
     if (refreshAgent) {
-      revalidate()
+      revalidator.revalidate()
     }
     setShowRateAgentModal(false)
   }
@@ -59,12 +59,15 @@ export default function AgentView() {
         <i className="bi bi-chevron-left align-middle" />
         Back
       </a>
-      <Row className="my-3">
-        <Col>
+      <div className="d-flex flex-row my-3">
+        <div className="w-100">
           <AgentInfo agent={agent} />
-        </Col>
-        <Col xs="auto" style={{ minWidth: 100 }}>
-          <div className="position-relative mb-3 text-center">
+        </div>
+        <div className="d-flex flex-column justify-content-end">
+          <div
+            className="position-relative mb-3 text-center"
+            style={{ minWidth: 150 }}
+          >
             <h4 className="mb-0">{t('agent.averageRatingTitle')}</h4>
             <span className="h2 fw-bold m-0">{agent.averageRating}</span>
             <span
@@ -76,13 +79,15 @@ export default function AgentView() {
           </div>
           <RateAgentButton
             openLogin={openLogin}
+            isLoading={revalidator.state !== 'idle'}
+            revalidate={revalidator.revalidate}
             showRatingModal={() => setShowRateAgentModal(true)}
             showConfirmationModal={() => setShowConfirmToRateModal(true)}
             isRateable={!!agent.isRateable}
             user={user}
           />
-        </Col>
-      </Row>
+        </div>
+      </div>
       <div className="mb-4">
         <div className="fw-normal mb-2 small">{t('agent.overallRatings')}</div>
         {agent.overallStats.map((r: Rating, i: number) => (

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -1,5 +1,4 @@
 import { useLoaderData, useNavigate, useRevalidator } from 'react-router-dom'
-import { Col, Row } from 'react-bootstrap'
 import AgentInfo from '../components/AgentInfo'
 import { AgentLoaderReturn } from '../loaders/agentLoader'
 import { Rating, Review } from '../types/Review'


### PR DESCRIPTION
- Align spinner in AsyncButton without margin
- LoginUIProvider postLogin callback, more flexible than redirectPath
- Hoist some state/functions for testability. Move unrateable to toast to avoid visual hiccups.
- Update tests
- Remove unused import
