### PR TITLE
[PRO-223] Push sourcemaps to rollbar

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "typescript": "^5.0.2",
     "vite": "^4.4.12",
     "vite-plugin-pwa": "^0.16.4",
+    "vite-plugin-rollbar": "^0.0.14",
     "vite-tsconfig-paths": "^4.2.0",
     "vitest": "^0.34.6"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -166,6 +166,9 @@ devDependencies:
   vite-plugin-pwa:
     specifier: ^0.16.4
     version: 0.16.4(vite@4.4.12)(workbox-build@7.0.0)(workbox-window@7.0.0)
+  vite-plugin-rollbar:
+    specifier: ^0.0.14
+    version: 0.0.14(vite@4.4.12)
   vite-tsconfig-paths:
     specifier: ^4.2.0
     version: 4.2.0(typescript@5.0.2)(vite@4.4.12)
@@ -4708,6 +4711,11 @@ packages:
       is-shared-array-buffer: 1.0.2
     dev: true
 
+  /assert-plus@1.0.0:
+    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
+    engines: {node: '>=0.8'}
+    dev: true
+
   /assert@2.0.0:
     resolution: {integrity: sha512-se5Cd+js9dXJnu6Ag2JFc00t+HmHOen+8Q+L7O9zI0PqQXr20uk2J0XQqMxZEeo5U50o8Nvmmx7dZrl+Ufr35A==}
     dependencies:
@@ -5318,6 +5326,10 @@ packages:
     resolution: {integrity: sha512-7a9a3D1k4UCVKnLhrgALyFcP7YCsLOQIxPd0dKjf/6GuPcgyiGP70ewWdCGrSK7evyhymi0qO4EqCmSJofDeYw==}
     dependencies:
       browserslist: 4.21.10
+    dev: true
+
+  /core-util-is@1.0.2:
+    resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     dev: true
 
   /core-util-is@1.0.3:
@@ -6094,6 +6106,11 @@ packages:
       yauzl: 2.10.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /extsprintf@1.4.1:
+    resolution: {integrity: sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==}
+    engines: {'0': node >=0.6.0}
     dev: true
 
   /fast-copy@2.1.7:
@@ -10035,6 +10052,15 @@ packages:
     engines: {node: '>= 0.8'}
     dev: true
 
+  /verror@1.10.1:
+    resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
+    engines: {node: '>=0.6.0'}
+    dependencies:
+      assert-plus: 1.0.0
+      core-util-is: 1.0.2
+      extsprintf: 1.4.1
+    dev: true
+
   /vite-node@0.34.6(@types/node@20.5.0)(sass@1.64.1):
     resolution: {integrity: sha512-nlBMJ9x6n7/Amaz6F3zJ97EBwR2FkzhBRxF5e+jE6LA3yi6Wtc2lyTij1OnDMIr34v5g/tVQtsVAzhT0jc5ygA==}
     engines: {node: '>=v14.18.0'}
@@ -10073,6 +10099,16 @@ packages:
       workbox-window: 7.0.0
     transitivePeerDependencies:
       - supports-color
+    dev: true
+
+  /vite-plugin-rollbar@0.0.14(vite@4.4.12):
+    resolution: {integrity: sha512-l25niefvFmnAKxvY6SpQL4bmqHBSTnOvbglLgcqUGoqA0u67ybcPABTxZLJIVmDNwhYVV6ZhotuCWWrAR3PJLA==}
+    peerDependencies:
+      vite: ^2.6.0 || ^3.0.0 || ^4.0.0
+    dependencies:
+      fast-glob: 3.3.1
+      verror: 1.10.1
+      vite: 4.4.12(@types/node@20.5.0)(sass@1.64.1)
     dev: true
 
   /vite-tsconfig-paths@4.2.0(typescript@5.0.2)(vite@4.4.12):

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,25 +4,49 @@ import { VitePWA } from 'vite-plugin-pwa'
 import react from '@vitejs/plugin-react'
 import pwaManifestConfig from './manifest.config.js'
 import tsconfigPaths from 'vite-tsconfig-paths'
+import { loadEnv } from 'vite'
 import { defineConfig } from 'vitest/dist/config.js'
+import viteRollbar from 'vite-plugin-rollbar'
 
 // References:
 // https://vitejs.dev/config/
 // https://vite-pwa-org.netlify.app/assets-generator/#example-using-minimal-preset
-export default defineConfig({
-  plugins: [tsconfigPaths(), react(), VitePWA(pwaManifestConfig)],
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['src/test/setup.ts'],
-  },
-  server: {
-    proxy: {
-      '/api': {
-        target: 'http://localhost:3000',
-        changeOrigin: false,
-        rewrite: (path) => path.replace(/^\/api/, ''),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  const plugins = [tsconfigPaths(), react(), VitePWA(pwaManifestConfig)]
+
+  if (env.ROLLBAR_ACCESS_TOKEN) {
+    console.log('Pushing source maps...')
+    plugins.push(
+      viteRollbar({
+        accessToken: env.ROLLBAR_ACCESS_TOKEN,
+        baseUrl: `https://${env.HOSTNAME}`,
+        version: '1.0',
+        ignoreUploadErrors: true,
+        silent: false,
+      }),
+    )
+  }
+
+  return {
+    build: {
+      sourcemap: true,
+    },
+    plugins,
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['src/test/setup.ts'],
+    },
+    server: {
+      proxy: {
+        '/api': {
+          target: 'http://localhost:3000',
+          changeOrigin: false,
+          rewrite: (path) => path.replace(/^\/api/, ''),
+        },
       },
     },
-  },
+  }
 })

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -17,7 +17,6 @@ export default defineConfig(({ mode }) => {
   const plugins = [tsconfigPaths(), react(), VitePWA(pwaManifestConfig)]
 
   if (env.ROLLBAR_ACCESS_TOKEN) {
-    console.log('Pushing source maps...')
     plugins.push(
       viteRollbar({
         accessToken: env.ROLLBAR_ACCESS_TOKEN,


### PR DESCRIPTION
THis is a nice-to-have, which may or may not work. Gives better error reporting when errors
occur in the JS.

- Add vite-plugin-rollbar
- Update config with plugin when ROLLBAR_ACCESS_TOKEN is defined
