### PR TITLE
Hotfix: OfficeView fix for PRO-262

### DIFF
--- a/src/api/agents.ts
+++ b/src/api/agents.ts
@@ -12,7 +12,7 @@ export async function get(id: string) {
 export async function list(officeId: string) {
   return await apiClient
     .get(`/offices/${officeId}/agents`)
-    .then((r) => r.data)
+    .then((r) => r.data.data)
     .catch(() => false)
 }
 


### PR DESCRIPTION
Now that results are paginated, the returned data shape is `{ data: [], meta: {...} }`, rather than just an array of items.

To be merged immediately after [PRO-262](https://github.com/ProjectProtocol/project-protocol-api/pull/145) goes live.
