### PR TITLE
Animated list component

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@contentful/rich-text-react-renderer": "^15.18.0",
     "@contentful/rich-text-types": "^16.3.0",
     "@hookform/error-message": "^2.0.1",
+    "@react-spring/web": "^9.7.3",
     "@rollbar/react": "^0.11.2",
     "@types/lodash-es": "^4.17.12",
     "axios": "^1.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ dependencies:
   '@hookform/error-message':
     specifier: ^2.0.1
     version: 2.0.1(react-dom@18.2.0)(react-hook-form@7.45.2)(react@18.2.0)
+  '@react-spring/web':
+    specifier: ^9.7.3
+    version: 9.7.3(react-dom@18.2.0)(react@18.2.0)
   '@rollbar/react':
     specifier: ^0.11.2
     version: 0.11.2(prop-types@15.8.1)(react@18.2.0)(rollbar@2.26.2)
@@ -2701,6 +2704,54 @@ packages:
     dependencies:
       '@swc/helpers': 0.5.1
       react: 18.2.0
+    dev: false
+
+  /@react-spring/animated@9.7.3(react@18.2.0):
+    resolution: {integrity: sha512-5CWeNJt9pNgyvuSzQH+uy2pvTg8Y4/OisoscZIR8/ZNLIOI+CatFBhGZpDGTF/OzdNFsAoGk3wiUYTwoJ0YIvw==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/shared': 9.7.3(react@18.2.0)
+      '@react-spring/types': 9.7.3
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/core@9.7.3(react@18.2.0):
+    resolution: {integrity: sha512-IqFdPVf3ZOC1Cx7+M0cXf4odNLxDC+n7IN3MDcVCTIOSBfqEcBebSv+vlY5AhM0zw05PDbjKrNmBpzv/AqpjnQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/animated': 9.7.3(react@18.2.0)
+      '@react-spring/shared': 9.7.3(react@18.2.0)
+      '@react-spring/types': 9.7.3
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/shared@9.7.3(react@18.2.0):
+    resolution: {integrity: sha512-NEopD+9S5xYyQ0pGtioacLhL2luflh6HACSSDUZOwLHoxA5eku1UPuqcJqjwSD6luKjjLfiLOspxo43FUHKKSA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/types': 9.7.3
+      react: 18.2.0
+    dev: false
+
+  /@react-spring/types@9.7.3:
+    resolution: {integrity: sha512-Kpx/fQ/ZFX31OtlqVEFfgaD1ACzul4NksrvIgYfIFq9JpDHFwQkMVZ10tbo0FU/grje4rcL4EIrjekl3kYwgWw==}
+    dev: false
+
+  /@react-spring/web@9.7.3(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-BXt6BpS9aJL/QdVqEIX9YoUy8CE6TJrU0mNCqSoxdXlIeNcEBWOfIyE6B14ENNsyQKS3wOWkiJfco0tCr/9tUg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      '@react-spring/animated': 9.7.3(react@18.2.0)
+      '@react-spring/core': 9.7.3(react@18.2.0)
+      '@react-spring/shared': 9.7.3(react@18.2.0)
+      '@react-spring/types': 9.7.3
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
     dev: false
 
   /@remix-run/router@1.7.2:

--- a/src/components/AnimatedList.tsx
+++ b/src/components/AnimatedList.tsx
@@ -1,0 +1,28 @@
+import { useSprings, animated } from '@react-spring/web'
+import { Children, Fragment } from 'react'
+
+interface IAnimatedList {
+  children: React.ReactNode
+  immediate?: boolean
+}
+
+export default function AnimatedList({
+  children,
+  immediate = false,
+}: IAnimatedList) {
+  const [springs] = useSprings(Children.count(children), (index: number) => ({
+    from: { opacity: 0, transform: 'translate3d(0, 30px, 0)' },
+    to: { opacity: 1, transform: 'translate3d(0, 0, 0)' },
+    delay: immediate ? 0 : index * 150,
+    easing: 'easeOutCubic',
+    immediate,
+  }))
+
+  return (
+    <Fragment>
+      {Children.map(children, (child, index) => {
+        return <animated.div style={springs[index]}>{child}</animated.div>
+      })}
+    </Fragment>
+  )
+}

--- a/src/components/AnimatedList.tsx
+++ b/src/components/AnimatedList.tsx
@@ -4,16 +4,21 @@ import { Children, Fragment } from 'react'
 interface IAnimatedList {
   children: React.ReactNode
   immediate?: boolean
+  delay?: number
 }
 
+/**
+ * Wraps any number of children in an animated container, animating them in sequence.
+ */
 export default function AnimatedList({
   children,
   immediate = false,
+  delay = 150,
 }: IAnimatedList) {
   const [springs] = useSprings(Children.count(children), (index: number) => ({
     from: { opacity: 0, transform: 'translate3d(0, 30px, 0)' },
     to: { opacity: 1, transform: 'translate3d(0, 0, 0)' },
-    delay: immediate ? 0 : index * 150,
+    delay: immediate ? 0 : index * delay,
     easing: 'easeOutCubic',
     immediate,
   }))

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -17,6 +17,7 @@ import ConfirmationModal from 'src/components/ConfirmationModal'
 import RateAgentButton from 'src/components/Agent/RateAgentButton'
 import { useLogin } from 'src/contexts/LoginUIProvider/LoginUIContext'
 import ModerationInfoModal from 'src/components/ModerationInfoModal'
+import AnimatedList from 'src/components/AnimatedList'
 
 export default function AgentView() {
   const { agent, reviews } = useLoaderData() as AgentLoaderReturn
@@ -113,13 +114,15 @@ export default function AgentView() {
         {t('agent.rating', { count: reviews.length })}
       </h4>
       <div className="vertical-rhythm">
-        {reviews.map((r: Review) => (
-          <ReviewCard
-            showModerationModal={() => setShowModerationModal(true)}
-            review={r}
-            key={`agent-review-${r.id}`}
-          />
-        ))}
+        <AnimatedList>
+          {reviews.map((r: Review) => (
+            <ReviewCard
+              showModerationModal={() => setShowModerationModal(true)}
+              review={r}
+              key={`agent-review-${r.id}`}
+            />
+          ))}
+        </AnimatedList>
       </div>
       <RateAgentModal
         agent={agent}

--- a/src/stories/AnimatedList.stories.tsx
+++ b/src/stories/AnimatedList.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import AnimatedList from 'src/components/AnimatedList'
+
+const meta: Meta<typeof AnimatedList> = {
+  title: 'Components/AnimatedList',
+  component: AnimatedList,
+  tags: ['autodocs'],
+}
+
+function generateChildren(key: string) {
+  const color = (i: number) =>
+    ['primary', 'secondary', 'meyer-lemon', 'loquat'][i % 4]
+  return Array(7)
+    .fill(0)
+    .map((_, i: number) => (
+      <div
+        key={`${key}-${i}`}
+        className={`my-3 border rounded p-3 w-50 text-center fw-semibold bg-${color(
+          i,
+        )}`}
+      >
+        <span>Item {i + 1}</span>
+      </div>
+    ))
+}
+
+export default meta
+type Story = StoryObj<typeof AnimatedList>
+
+export const Basic: Story = {
+  args: {
+    children: generateChildren('basic'),
+  },
+}
+
+/**
+ * Set immediate to true to skip animation for items.
+ */
+export const Immediate: Story = {
+  args: {
+    children: generateChildren('immediate'),
+    immediate: true,
+  },
+}

--- a/src/stories/AnimatedList.stories.tsx
+++ b/src/stories/AnimatedList.stories.tsx
@@ -27,6 +27,9 @@ function generateChildren(key: string) {
 export default meta
 type Story = StoryObj<typeof AnimatedList>
 
+/**
+ * The default animation
+ */
 export const Basic: Story = {
   args: {
     children: generateChildren('basic'),
@@ -40,5 +43,15 @@ export const Immediate: Story = {
   args: {
     children: generateChildren('immediate'),
     immediate: true,
+  },
+}
+
+/**
+ * Delay between item animations is 150ms by default but can be adjusted.
+ */
+export const SlowDelay: Story = {
+  args: {
+    children: generateChildren('slow'),
+    delay: 500,
   },
 }


### PR DESCRIPTION
I'm plucking this out of some of the experimentation I've been doing on list handling, to reduce the number of files/changes in forthcoming PRs.

AnimatedList is meant to give us a place to have a single, canonical place to define how we want a list to render onto the screen. This branch adds a story and uses it for the list of reviews on an agent.

Changes
---
* Adds [react-spring animation library](https://www.react-spring.dev/) -- very powerful and concise animation library I've worked with lots in the past.
* Adds an AnimatedList component which wraps all direct children in an animated container.
* Wrap agent reviews in AnimatedList in the AgentView.
![animated-list](https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/feef974d-c4c4-43ae-940d-6b7861810673)

Testing
---
* In the deploy preview, wiew a few agents with multiple reviews to see the AnimatedList in action.
* (optional) You can fire up storybook locally (run `pnpm storybook` from project root), and see the AnimatedList component doc.