### PR TITLE
[PRO-302] Add "optional" to Additional Comments label, reduce default row size …

### DIFF
--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -76,13 +76,13 @@ export default function RateAgentModal({
         <RateAgentRatingRadio control={control} name="respectful" />
         <RateAgentRatingRadio control={control} name="availability" />
         <RateAgentTags control={control} />
-        <div className="mb-3">
-          <h4>{t('ratings.additionalComments')}</h4>
+        <div className="mb-5">
+          <h4>{t('ratings.additionalComments') + ' ' + t('ui.optional')}</h4>
           <p>{t('ratings.additionalCommentsHelpText')}</p>
           <FormControl
             as="textarea"
             placeholder={t('ratings.additionalCommentsPlaceholder')}
-            rows={5}
+            rows={2}
             {...register('reviewInput')}
           />
         </div>


### PR DESCRIPTION
Changes
---
* Add "(optional)" to the additional comments field label.
* Reduce default row size of textbox from 5 to 2 to de-emphasize.

<img width="387" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/40d8c082-1b2c-4e0c-a3a5-c06dfec539f4">
