### PR TITLE
[PRO-296] Resource likes/dislikes UI

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -253,6 +253,7 @@
     "suggestResource": "Suggest a resource",
     "title": "Resources",
     "searchPlaceholder": "Search for a resource",
+    "signInRequired": "You must be logged in to like or dislike resources.",
     "locationFilter": {
       "distanceAccessibilityLabel": "Choose a distance to search within",
       "locationAccessibilityLabel": "Enter a location to search near",
@@ -292,6 +293,7 @@
     "title": "Terms of Service"
   },
   "ui": {
+    "dismiss": "Dismiss",
     "iconAlt": "icon",
     "ppLogoAlt": "Project protocol logo",
     "submit": "Submit",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -191,6 +191,7 @@
     "suggestResource": "Sugerir un recurso",
     "title": "Recursos",
     "searchPlaceholder": "Buscar recursos",
+    "signInRequired": "Debes iniciar sesión para dar 'me gusta' o 'no me gusta' a los recursos.",
     "locationFilter": {
       "distanceAccessibilityLabel": "Elige una distancia para buscar dentro.",
       "locationAccessibilityLabel": "Ingresa una ubicación para buscar cerca.",
@@ -227,6 +228,7 @@
   },
 
   "ui": {
+    "dismiss": "Descartar",
     "submit": "Enviar",
     "back": "Atrás",
     "cancel": "Cancelar",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -188,10 +188,6 @@
       "hide": "Ocultar filtros",
       "show": "Mostrar filtros"
     },
-    "suggestResource": "Sugerir un recurso",
-    "title": "Recursos",
-    "searchPlaceholder": "Buscar recursos",
-    "signInRequired": "Debes iniciar sesión para dar 'me gusta' o 'no me gusta' a los recursos.",
     "locationFilter": {
       "distanceAccessibilityLabel": "Elige una distancia para buscar dentro.",
       "locationAccessibilityLabel": "Ingresa una ubicación para buscar cerca.",
@@ -201,8 +197,10 @@
       "title": "Almacén",
       "within": "A menos de"
     },
+    "searchPlaceholder": "Buscar recursos",
+    "signInRequired": "Debes iniciar sesión para dar 'me gusta' o 'no me gusta' a los recursos.",
+    "suggestResource": "Sugerir un recurso",
     "tags": {
-      "title": "Etiquetas",
       "advocacy": "Abogacía",
       "education": "Educación",
       "familyReunification": "Reunificación Familiar",
@@ -213,8 +211,10 @@
       "lifeSkills": "Habilidades para la Vida",
       "mentalHealthSupport": "Apoyo de Salud Mental",
       "reentryProgram": "Programa de Reingreso",
-      "serviceProviders": "Proveedores de Servicios"
-    }
+      "serviceProviders": "Proveedores de Servicios",
+      "title": "Etiquetas"
+    },
+    "title": "Recursos"
   },
   "search": {
     "addAnAgent": "Agregar agente",

--- a/src/api/resources.ts
+++ b/src/api/resources.ts
@@ -17,3 +17,21 @@ export async function list(params: IResourceListParams) {
 
   return result
 }
+
+export async function like(id: number) {
+  const result = await apiClient
+    .post(`resources/${id}/like`)
+    .then((r) => r.data)
+    .catch(() => false)
+
+  return result
+}
+
+export async function dislike(id: number) {
+  const result = await apiClient
+    .post(`resources/${id}/dislike`)
+    .then((r) => r.data)
+    .catch(() => false)
+
+  return result
+}

--- a/src/components/LocaleSwitcher.tsx
+++ b/src/components/LocaleSwitcher.tsx
@@ -13,7 +13,7 @@ type Languages = {
 
 const languages: Languages = {
   en: { nativeName: 'English' },
-  es: { nativeName: 'Spanish' },
+  es: { nativeName: 'Español' },
 }
 
 export default function LocaleSwitcher() {

--- a/src/components/NotificationArea.tsx
+++ b/src/components/NotificationArea.tsx
@@ -1,17 +1,14 @@
 import { Toaster } from 'react-hot-toast'
-import useWindowSize from 'src/hooks/useWindowSize'
 
 // Options: https://react-hot-toast.com/docs/toaster
 export default function NotificationArea() {
-  const [width] = useWindowSize()
-
   return (
     <Toaster
-      position={width < 768 ? 'bottom-center' : 'top-center'}
+      position='top-center'
       toastOptions={{
         className: 'text-white',
         style: {
-          backgroundColor: 'rgba(0,0,0,0.85)',
+          backgroundColor: 'rgba(0,0,0,0.95)',
         },
       }}
     />

--- a/src/components/NotificationArea.tsx
+++ b/src/components/NotificationArea.tsx
@@ -1,10 +1,13 @@
 import { Toaster } from 'react-hot-toast'
+import useWindowSize from 'src/hooks/useWindowSize'
 
 // Options: https://react-hot-toast.com/docs/toaster
 export default function NotificationArea() {
+  const [width] = useWindowSize()
+
   return (
     <Toaster
-      position="top-center"
+      position={width < 768 ? 'bottom-center' : 'top-center'}
       toastOptions={{
         className: 'text-white',
         style: {

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -140,7 +140,7 @@ export default function ResourceCard({
         </div>
         <div className="d-flex flex-row flex-wrap gap-2 align-items-center">
           <div className="d-flex flex-row gap-1">
-            <span>{resource.cachedVotesUp}</span>
+            <span>{resource.votesUp}</span>
             <i
               className={`bi me-1 align-middle bi-hand-thumbs-up${
                 isCurrentUserLiked ? '-fill' : ''
@@ -150,7 +150,7 @@ export default function ResourceCard({
             />
           </div>
           <div className="d-flex flex-row gap-1">
-            <span>{resource.cachedVotesDown}</span>
+            <span>{resource.votesDown}</span>
             <i
               className={`bi me-1 align-middle bi-hand-thumbs-down${
                 isCurrentUserDisliked ? '-fill' : ''

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -3,7 +3,6 @@ import { Card } from 'react-bootstrap'
 import Resource, { ResourceTag } from 'src/types/Resource'
 import { useTranslation } from 'react-i18next'
 import { useMemo, useState } from 'react'
-import { truncate } from 'lodash-es'
 import ResourceVoteControls from './ResourceVoteControls'
 import { dislike, like } from 'src/api/resources'
 import {
@@ -40,7 +39,6 @@ export default function ResourceCard({
     email,
     isOnline,
   } = resource
-  const [expanded, setExpanded] = useState(false)
   const { openLogin } = useLogin()
   const locationLabel = isOnline
     ? 'Online'
@@ -141,16 +139,7 @@ export default function ResourceCard({
           </div>
         </div>
         <p>
-          {expanded ? description : truncate(description, { length: 75 })}
-          {description.length > 100 && (
-            <a
-              onClick={() => setExpanded(!expanded)}
-              className="ms-1"
-              role="button"
-            >
-              {expanded ? 'show less' : 'show more'}
-            </a>
-          )}
+          {description}
         </p>
         <div className="d-flex flex-column gap-1">
           {addressLabel && (

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -2,24 +2,31 @@ import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
 import Resource, { ResourceTag } from 'src/types/Resource'
 import { useTranslation } from 'react-i18next'
-import { useMemo } from 'react'
-import { useSearchParams } from 'react-router-dom'
+import { useMemo, useState } from 'react'
+import { truncate } from 'lodash-es'
+import {
+  InfiniteData,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
+import { like, dislike } from 'src/api/resources'
+import SearchMeta from 'src/types/SearchMeta'
+
+type Page<T> = {
+  data: T[]
+  meta: SearchMeta
+}
 
 export default function ResourceCard({
   resource,
+  queryKey,
 }: {
   resource: Resource
   index: number
+  queryKey: string[]
 }) {
   const { t } = useTranslation()
-  const [, setSearchParams] = useSearchParams()
-
-  const handleTagClick = (tag: ResourceTag) => {
-    setSearchParams((prev) => {
-      prev.set('tags', tag)
-      return prev
-    }, { replace: true })
-  }
+  const queryClient = useQueryClient()
   const {
     url,
     name,
@@ -32,7 +39,10 @@ export default function ResourceCard({
     phone,
     email,
     isOnline,
+    isCurrentUserLiked,
+    isCurrentUserDisliked,
   } = resource
+  const [expanded, setExpanded] = useState(false)
   const locationLabel = isOnline
     ? 'Online'
     : city && state
@@ -44,56 +54,112 @@ export default function ResourceCard({
       return [street, city, state, zip].join(', ')
     }
   }, [street, city, state, zip])
+
+  function updateResourceInList({ resource }: { resource: Resource }) {
+    const newResource = resource
+    queryClient.setQueryData(queryKey, (prev: InfiniteData<Page<Resource>>) => {
+      const newPages = prev.pages.map((page) => {
+        const newData = page.data.map((r) =>
+          r.id === newResource.id ? { ...r, ...newResource } : r,
+        )
+        return { data: newData, meta: page.meta }
+      })
+      return { ...prev, pages: newPages }
+    })
+  }
+
+  const likeMutation = useMutation({
+    mutationFn: () => like(resource.id),
+    onSuccess: updateResourceInList,
+  })
+
+  const dislikeMutation = useMutation({
+    mutationFn: () => dislike(resource.id),
+    onSuccess: updateResourceInList,
+  })
+
   return (
     <Card body>
-      <div className="d-flex flex-row align-items-top mb-3">
-        <div
-          className="bg-white d-flex justify-content-center align-items-center rounded rounded-circle border me-2"
-          style={{ width: '30px', height: '30px', padding: '6px' }}
-        >
-          <img
-            src={`https://s2.googleusercontent.com/s2/favicons?domain_url=${url}`}
-          />
-        </div>
-        <div className="flex flex-column">
-          <a
-            href={url}
-            target="_blank"
-            className="fs-3 fw-semibold d-block link-cobalt"
+      <div className="vertical-rhythm-sm">
+        <div className="d-flex flex-row align-items-top">
+          <div
+            className="bg-white d-flex justify-content-center align-items-center rounded rounded-circle border me-2"
+            style={{ width: '30px', height: '30px', padding: '6px' }}
           >
-            {name}
+            <img
+              src={`https://s2.googleusercontent.com/s2/favicons?domain_url=${url}`}
+            />
+          </div>
+          <div className="flex flex-column">
+            <a
+              href={url}
+              target="_blank"
+              className="fs-3 fw-semibold d-block link-cobalt"
+            >
+              {name}
+            </a>
+            <div className="text-dark small text-break">{url}</div>
+            {locationLabel && (
+              <div className="d-flex flex-row">
+                <i className="bi bi-geo-alt-fill me-1 text-dark small" />
+                <span className="small">{locationLabel}</span>
+              </div>
+            )}
+          </div>
+        </div>
+        <p>
+          {expanded ? description : truncate(description, { length: 100 })}
+          <a
+            onClick={() => setExpanded(!expanded)}
+            className="ms-1"
+            role="button"
+          >
+            {expanded ? 'Say less' : 'Say more'}
           </a>
-          <div className="text-dark small text-break">{url}</div>
-          {locationLabel && (
-            <div className="d-flex flex-row">
-              <i className="bi bi-geo-alt-fill me-1 text-dark small" />
-              <span className="small">{locationLabel}</span>
-            </div>
+        </p>
+        <div className="d-flex flex-column gap-1">
+          {addressLabel && (
+            <a
+              href={`https://maps.google.com/?q=${addressLabel}`}
+              target="_blank"
+            >
+              {addressLabel}
+            </a>
           )}
+          {phone && <a href={`tel:+1${phone}`}>{phone}</a>}
+          {email && <a href={`mailto:${email}`}>{email}</a>}
         </div>
-      </div>
-      <p className="mb-3">{description}</p>
-      <div className="mb-3 d-flex flex-column gap-1">
-        {addressLabel && (
-          <a
-            href={`https://maps.google.com/?q=${addressLabel}`}
-            target="_blank"
-          >
-            {addressLabel}
-          </a>
-        )}
-        {phone && <a href={`tel:+1${phone}`}>{phone}</a>}
-        {email && <a href={`mailto:${email}`}>{email}</a>}
-      </div>
-      <div className="d-flex flex-row flex-wrap gap-2">
-        {tagList.map((tag: ResourceTag, i: number) => (
-          <CategoryPill
-            key={`resource-${i}-${tag}`}
-            active={true}
-            label={t(`resources.tags.${tag}`)}
-            onClick={() => handleTagClick(tag)}
-          />
-        ))}
+        <div className="d-flex flex-row flex-wrap gap-2">
+          {tagList.map((tag: ResourceTag, i: number) => (
+            <CategoryPill
+              key={`resource-${i}-${tag}`}
+              active={true}
+              label={t(`resources.tags.${tag}`)}
+            />
+          ))}
+        </div>
+        <div className="d-flex flex-row flex-wrap gap-2 align-items-center">
+          <div className="d-flex flex-row gap-1">
+            <span>{resource.cachedVotesUp}</span>
+            <i
+              className={`bi me-1 align-middle bi-hand-thumbs-up${
+                isCurrentUserLiked ? '-fill' : ''
+              }`}
+              role="button"
+              onClick={() => likeMutation.mutate()}
+            />
+          </div>
+          <div className="d-flex flex-row gap-1">
+            <span>{resource.cachedVotesDown}</span>
+            <i
+              className={`bi me-1 align-middle bi-hand-thumbs-down${
+                isCurrentUserDisliked ? '-fill' : ''
+              }`}
+              role="button"
+              onClick={() => dislikeMutation.mutate()}
+            />
+          </div>
+        </div>
       </div>
     </Card>
   )

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -1,5 +1,5 @@
 import CategoryPill from './CategoryPill'
-import { Card } from 'react-bootstrap'
+import { Button, Card } from 'react-bootstrap'
 import Resource, { ResourceTag } from 'src/types/Resource'
 import { useTranslation } from 'react-i18next'
 import { useMemo } from 'react'
@@ -79,27 +79,27 @@ export default function ResourceCard({
 
   function showUnauthorizedToast() {
     toast(
-      (t) => (
+      (toastObject) => (
         <div>
           You must be logged in to like or dislike resources.
           <div className="d-flex py-2 flex-row justify-content-between align-items-center">
             <a
               role="button"
               className="link-light"
-              onClick={() => toast.dismiss(t.id)}
+              onClick={() => toast.dismiss(toastObject.id)}
             >
               Dismiss
             </a>
-            <a
-              role="button"
-              className="link-light"
+            <Button
+              size="sm"
+              variant="light"
               onClick={() => {
-                toast.dismiss(t.id)
+                toast.dismiss(toastObject.id)
                 openLogin(LOGIN_PAGES.SIGN_IN)
               }}
             >
-              Sign in
-            </a>
+              {t('account.login.login')}
+            </Button>
           </div>
         </div>
       ),

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -2,7 +2,7 @@ import CategoryPill from './CategoryPill'
 import { Card } from 'react-bootstrap'
 import Resource, { ResourceTag } from 'src/types/Resource'
 import { useTranslation } from 'react-i18next'
-import { useMemo, useState } from 'react'
+import { useMemo } from 'react'
 import ResourceVoteControls from './ResourceVoteControls'
 import { dislike, like } from 'src/api/resources'
 import {

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -81,14 +81,14 @@ export default function ResourceCard({
     toast(
       (toastObject) => (
         <div>
-          You must be logged in to like or dislike resources.
+          {t('resources.signInRequired')}
           <div className="d-flex py-2 flex-row justify-content-between align-items-center">
             <a
               role="button"
               className="link-light"
               onClick={() => toast.dismiss(toastObject.id)}
             >
-              Dismiss
+              {t('ui.dismiss')}
             </a>
             <Button
               size="sm"
@@ -138,9 +138,7 @@ export default function ResourceCard({
             )}
           </div>
         </div>
-        <p>
-          {description}
-        </p>
+        <p>{description}</p>
         <div className="d-flex flex-column gap-1">
           {addressLabel && (
             <a

--- a/src/components/Resources/ResourceCard.tsx
+++ b/src/components/Resources/ResourceCard.tsx
@@ -141,14 +141,16 @@ export default function ResourceCard({
           </div>
         </div>
         <p>
-          {expanded ? description : truncate(description, { length: 100 })}
-          <a
-            onClick={() => setExpanded(!expanded)}
-            className="ms-1"
-            role="button"
-          >
-            {expanded ? 'show less' : 'show more'}
-          </a>
+          {expanded ? description : truncate(description, { length: 75 })}
+          {description.length > 100 && (
+            <a
+              onClick={() => setExpanded(!expanded)}
+              className="ms-1"
+              role="button"
+            >
+              {expanded ? 'show less' : 'show more'}
+            </a>
+          )}
         </p>
         <div className="d-flex flex-column gap-1">
           {addressLabel && (

--- a/src/components/Resources/ResourceVoteControls.tsx
+++ b/src/components/Resources/ResourceVoteControls.tsx
@@ -1,0 +1,75 @@
+import {
+  InfiniteData,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query'
+import classNames from 'classnames'
+import { dislike, like } from 'src/api/resources'
+import Resource from 'src/types/Resource'
+import { Page } from 'src/types/SearchMeta'
+
+export default function ResourceVoteControls({
+  resource,
+  queryKey,
+}: {
+  resource: Resource
+  queryKey: string[]
+}) {
+  const queryClient = useQueryClient()
+
+  function updateResourceInList({ resource }: { resource: Resource }) {
+    const newResource = resource
+    queryClient.setQueryData(queryKey, (prev: InfiniteData<Page<Resource>>) => {
+      const newPages = prev.pages.map((page) => {
+        const newData = page.data.map((r) =>
+          r.id === newResource.id ? { ...r, ...newResource } : r,
+        )
+        return { data: newData, meta: page.meta }
+      })
+      return { ...prev, pages: newPages }
+    })
+  }
+
+  const likeMutation = useMutation({
+    mutationFn: () => like(resource.id),
+    onSuccess: updateResourceInList,
+  })
+
+  const dislikeMutation = useMutation({
+    mutationFn: () => dislike(resource.id),
+    onSuccess: updateResourceInList,
+  })
+
+  return (
+    <div className="d-flex flex-row flex-wrap gap-2 align-items-center">
+      <div
+        className={classNames('d-flex flex-row gap-1', {
+          'text-light-cobalt': resource.isCurrentUserLiked,
+        })}
+      >
+        <span>{resource.votesUp}</span>
+        <i
+          className={`bi me-1 align-middle bi-hand-thumbs-up${
+            resource.isCurrentUserLiked ? '-fill' : ''
+          }`}
+          role="button"
+          onClick={() => likeMutation.mutate()}
+        />
+      </div>
+      <div
+        className={classNames('d-flex flex-row gap-1', {
+          'text-rating-1': resource.isCurrentUserDisliked,
+        })}
+      >
+        <span>{resource.votesDown}</span>
+        <i
+          className={`bi me-1 align-middle bi-hand-thumbs-down${
+            resource.isCurrentUserDisliked ? '-fill' : ''
+          }`}
+          role="button"
+          onClick={() => dislikeMutation.mutate()}
+        />
+      </div>
+    </div>
+  )
+}

--- a/src/components/Resources/ResourceVoteControls.tsx
+++ b/src/components/Resources/ResourceVoteControls.tsx
@@ -1,73 +1,36 @@
-import {
-  InfiniteData,
-  useMutation,
-  useQueryClient,
-} from '@tanstack/react-query'
-import classNames from 'classnames'
-import { dislike, like } from 'src/api/resources'
 import Resource from 'src/types/Resource'
-import { Page } from 'src/types/SearchMeta'
+
+interface IResourceVoteControls {
+  resource: Resource
+  onLike: () => void
+  onDislike: () => void
+}
 
 export default function ResourceVoteControls({
   resource,
-  queryKey,
-}: {
-  resource: Resource
-  queryKey: string[]
-}) {
-  const queryClient = useQueryClient()
-
-  function updateResourceInList({ resource }: { resource: Resource }) {
-    const newResource = resource
-    queryClient.setQueryData(queryKey, (prev: InfiniteData<Page<Resource>>) => {
-      const newPages = prev.pages.map((page) => {
-        const newData = page.data.map((r) =>
-          r.id === newResource.id ? { ...r, ...newResource } : r,
-        )
-        return { data: newData, meta: page.meta }
-      })
-      return { ...prev, pages: newPages }
-    })
-  }
-
-  const likeMutation = useMutation({
-    mutationFn: () => like(resource.id),
-    onSuccess: updateResourceInList,
-  })
-
-  const dislikeMutation = useMutation({
-    mutationFn: () => dislike(resource.id),
-    onSuccess: updateResourceInList,
-  })
-
+  onLike,
+  onDislike,
+}: IResourceVoteControls) {
   return (
-    <div className="d-flex flex-row flex-wrap gap-2 align-items-center">
-      <div
-        className={classNames('d-flex flex-row gap-1', {
-          'text-light-cobalt': resource.isCurrentUserLiked,
-        })}
-      >
+    <div className="d-flex flex-row flex-wrap gap-2 align-items-center text-dark">
+      <div className={'d-flex flex-row gap-1'}>
         <span>{resource.votesUp}</span>
         <i
           className={`bi me-1 align-middle bi-hand-thumbs-up${
             resource.isCurrentUserLiked ? '-fill' : ''
           }`}
           role="button"
-          onClick={() => likeMutation.mutate()}
+          onClick={onLike}
         />
       </div>
-      <div
-        className={classNames('d-flex flex-row gap-1', {
-          'text-rating-1': resource.isCurrentUserDisliked,
-        })}
-      >
+      <div className={'d-flex flex-row gap-1'}>
         <span>{resource.votesDown}</span>
         <i
           className={`bi me-1 align-middle bi-hand-thumbs-down${
             resource.isCurrentUserDisliked ? '-fill' : ''
           }`}
           role="button"
-          onClick={() => dislikeMutation.mutate()}
+          onClick={onDislike}
         />
       </div>
     </div>

--- a/src/components/Resources/ResourceVoteControls.tsx
+++ b/src/components/Resources/ResourceVoteControls.tsx
@@ -14,8 +14,9 @@ export default function ResourceVoteControls({
   return (
     <div className="d-flex flex-row flex-wrap gap-2 align-items-center text-dark">
       <div className={'d-flex flex-row gap-1'}>
-        <span>{resource.votesUp}</span>
+        <span data-testid="likes-count">{resource.votesUp}</span>
         <i
+          data-testid="like-button"
           className={`bi me-1 align-middle bi-hand-thumbs-up${
             resource.isCurrentUserLiked ? '-fill' : ''
           }`}
@@ -24,8 +25,9 @@ export default function ResourceVoteControls({
         />
       </div>
       <div className={'d-flex flex-row gap-1'}>
-        <span>{resource.votesDown}</span>
+        <span data-testid="dislikes-count">{resource.votesDown}</span>
         <i
+          data-testid="dislike-button"
           className={`bi me-1 align-middle bi-hand-thumbs-down${
             resource.isCurrentUserDisliked ? '-fill' : ''
           }`}

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -6,7 +6,6 @@ import ResourceFilters from 'src/components/Resources/ResourceFilters'
 import Resource, { ResourceTag } from 'src/types/Resource'
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import useLoadingBar from 'src/hooks/useLoadingBar'
-import { useMemo } from 'react'
 import SearchBar from 'src/components/SearchBar'
 import { ApiResources } from 'src/api'
 import { InView } from 'react-intersection-observer'
@@ -16,33 +15,18 @@ import AnimatedList from 'src/components/AnimatedList'
 export default function Resources() {
   const { t } = useTranslation()
   const [params, setParams] = useSearchParams()
-  const searchParam: string = useMemo(
-    () => params.get('search') || '',
-    [params],
-  )
-  const tagsParam: ResourceTag[] = useMemo(
-    () => params.getAll('tags') as ResourceTag[],
-    [params],
-  )
-  const distanceParam = useMemo(
-    () => params.get('distance') || undefined,
-    [params],
-  )
-  const locationParam = useMemo(
-    () => params.get('location') || undefined,
-    [params],
-  )
+  const searchParam: string = params.get('search') || ''
+  const tagsParam: ResourceTag[] = params.getAll('tags') as ResourceTag[]
+  const distanceParam = params.get('distance') || undefined
+  const locationParam = params.get('location') || undefined
 
-  const queryKey = useMemo(
-    () => [
-      'resourceSearch',
-      searchParam,
-      distanceParam,
-      locationParam,
-      ...tagsParam,
-    ],
-    [searchParam, distanceParam, locationParam, tagsParam],
-  )
+  const queryKey = [
+    'resourceSearch',
+    searchParam,
+    distanceParam,
+    locationParam,
+    ...tagsParam,
+  ]
 
   const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
     queryKey,

--- a/src/pages/Resources.tsx
+++ b/src/pages/Resources.tsx
@@ -33,14 +33,19 @@ export default function Resources() {
     [params],
   )
 
-  const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
-    queryKey: [
+  const queryKey = useMemo(
+    () => [
       'resourceSearch',
       searchParam,
       distanceParam,
-      location,
+      locationParam,
       ...tagsParam,
     ],
+    [searchParam, distanceParam, locationParam, tagsParam],
+  )
+
+  const { data, fetchNextPage, hasNextPage, isFetching } = useInfiniteQuery({
+    queryKey,
     queryFn: ({ pageParam = 0 }) =>
       ApiResources.list({
         search: searchParam,
@@ -114,7 +119,12 @@ export default function Resources() {
         {(data || { pages: [] }).pages.map((p) => (
           <AnimatedList key={`resource-list-${p.meta.page}`}>
             {p.data.map((r: Resource, i: number) => (
-              <ResourceCard resource={r} index={i} key={`resource-card-${i}`} />
+              <ResourceCard
+                resource={r}
+                index={i}
+                key={`resource-card-${i}`}
+                queryKey={queryKey as string[]}
+              />
             ))}
           </AnimatedList>
         ))}

--- a/src/stories/Colors.mdx
+++ b/src/stories/Colors.mdx
@@ -1,5 +1,8 @@
 import { Meta, ColorPalette, ColorItem } from '@storybook/blocks'
-import bootstrapVariables, { ratingColors } from '../util/bootstrapVariables.ts'
+import bootstrapVariables, {
+  ratingColors,
+  themeColors,
+} from '../util/bootstrapVariables.ts'
 
 <Meta title="Colors" />
 
@@ -16,7 +19,7 @@ Examples of commonly used utilities:
 
 <ColorPalette>
   {Object.entries(bootstrapVariables)
-    .filter(([name, _]) => !name.startsWith('rating'))
+    .filter(([name, _]) => themeColors.includes(name))
     .map(([colorName, value]) => (
       <ColorItem
         key={`swatch-${colorName}`}

--- a/src/test/components/LocaleSwitcher.test.tsx
+++ b/src/test/components/LocaleSwitcher.test.tsx
@@ -22,7 +22,7 @@ describe('LocaleSwitcher', () => {
     render(<LocaleSwitcher />)
 
     const englishOption = screen.getByText('English')
-    const spanishOption = screen.getByText('Spanish')
+    const spanishOption = screen.getByText('Español')
 
     expect(englishOption).toBeInTheDocument()
     expect(spanishOption).toBeInTheDocument()
@@ -31,7 +31,7 @@ describe('LocaleSwitcher', () => {
   test('changes language when an option is clicked', async () => {
     render(<LocaleSwitcher />)
     const englishOption = screen.getByText('English')
-    const spanishOption = screen.getByText('Spanish')
+    const spanishOption = screen.getByText('Español')
 
     await fireEvent.click(spanishOption)
     expect(i18n.changeLanguage).toHaveBeenCalledWith('es', expect.any(Function))

--- a/src/test/components/Resources/ResourceVoteControls.test.tsx
+++ b/src/test/components/Resources/ResourceVoteControls.test.tsx
@@ -1,0 +1,92 @@
+import { render, fireEvent } from '@testing-library/react'
+import ResourceVoteControls from 'src/components/Resources/ResourceVoteControls'
+import Resource from 'src/types/Resource'
+
+describe('ResourceVoteControls', () => {
+  const resource = {
+    votesUp: 0,
+    votesDown: 0,
+    isCurrentUserLiked: false,
+    isCurrentUserDisliked: false,
+  } as Resource
+
+  it('should call onLike when the like button is clicked', () => {
+    const onLikeMock = vitest.fn()
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={resource}
+        onLike={onLikeMock}
+        onDislike={() => {}}
+      />,
+    )
+
+    fireEvent.click(getByTestId('like-button'))
+
+    expect(onLikeMock).toHaveBeenCalled()
+  })
+
+  it('should call onDislike when the dislike button is clicked', () => {
+    const onDislikeMock = vitest.fn()
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={resource}
+        onLike={() => {}}
+        onDislike={onDislikeMock}
+      />,
+    )
+
+    fireEvent.click(getByTestId('dislike-button'))
+
+    expect(onDislikeMock).toHaveBeenCalled()
+  })
+
+  it("displays the resource's likes count", () => {
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={{ ...resource, votesUp: 10 }}
+        onLike={() => {}}
+        onDislike={() => {}}
+      />,
+    )
+
+    expect(getByTestId('likes-count')).toHaveTextContent('10')
+  })
+
+  it("displays the resource's dislikes count", () => {
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={{ ...resource, votesDown: 5 }}
+        onLike={() => {}}
+        onDislike={() => {}}
+      />,
+    )
+
+    expect(getByTestId('dislikes-count')).toHaveTextContent('5')
+  })
+
+  it('shows a filled like button when the resource is liked by the current user', () => {
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={{ ...resource, isCurrentUserLiked: true }}
+        onLike={() => {}}
+        onDislike={() => {}}
+      />,
+    )
+
+    expect(getByTestId('like-button')).toHaveClass('bi-hand-thumbs-up-fill')
+  })
+
+  it('shows a filled dislike button when the resource is disliked by the current user', () => {
+    const { getByTestId } = render(
+      <ResourceVoteControls
+        resource={{ ...resource, isCurrentUserDisliked: true }}
+        onLike={() => {}}
+        onDislike={() => {}}
+      />,
+    )
+
+    expect(getByTestId('dislike-button')).toHaveClass(
+      'bi-hand-thumbs-down-fill',
+    )
+  })
+})

--- a/src/types/Resource.ts
+++ b/src/types/Resource.ts
@@ -29,9 +29,9 @@ type Resource = {
   tagList: ResourceTag[]
   isCurrentUserLiked?: boolean
   isCurrentUserDisliked?: boolean
-  cachedVotesScore: number
-  cachedVotesUp: number
-  cachedVotesDown: number
+  votesScore: number
+  votesUp: number
+  votesDown: number
   type: 'Resource'
 }
 

--- a/src/types/Resource.ts
+++ b/src/types/Resource.ts
@@ -27,6 +27,11 @@ type Resource = {
   phone?: string
   url?: string
   tagList: ResourceTag[]
+  isCurrentUserLiked?: boolean
+  isCurrentUserDisliked?: boolean
+  cachedVotesScore: number
+  cachedVotesUp: number
+  cachedVotesDown: number
   type: 'Resource'
 }
 

--- a/src/types/SearchMeta.ts
+++ b/src/types/SearchMeta.ts
@@ -4,4 +4,9 @@ type SearchMeta = {
   totalPages: number
 }
 
+export type Page<T> = {
+  data: T[]
+  meta: SearchMeta
+}
+
 export default SearchMeta


### PR DESCRIPTION
Changes
---
* Add resource like/dislike API client functions
* Add ResourceVoteControls component and test, for showing and updating like/dislike counts.
* Show toast when user is not authenticated
* Truncate resource description if more than 100 characters. TODO: translate Show more/less and get design feedback.

Testing:
---
* Try liking/disliking when not signed in
* Try liking/disliking when signed in
* Check that counts update and make sense.

📸 Screenshots
---
Outline icons when user hasn't voted on a resource:
<img width="556" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/e8c6b751-d4ee-488a-98f0-b9d1d0056645">

Filled in icons when user has voted:
<img width="560" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/37308dfd-742c-481e-a54a-b2c42337cf66">

Alert when not signed in:
<img width="425" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/23d1cb83-cc26-45dc-a660-048e62ae767b">
en Español:
<img width="330" alt="image" src="https://github.com/ProjectProtocol/project-protocol-web/assets/6488787/0ca07107-5391-41c1-8683-aaf914a9fbbe">

