### PR TITLE
copy-fix-4-22-24

### DIFF
--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -110,7 +110,7 @@
     "title": "Inicio",
     "voteDescription": "Las personas con libertad condicional tienen derecho a votar",
     "voteTitle": "Registrarse para votar",
-    "welcomeMessage": "Recursos, apoyo, y compartiendo experiencias durante us reingreso a la sociedad.",
+    "welcomeMessage": "Recursos, apoyo, y compartiendo experiencias durante tu reingreso a la sociedad.",
     "welcomeTitle": "Bienvenido a Project Protocol",
     "moreResources": "Más recursos"
   },


### PR DESCRIPTION
Fixes typo in Spanish copy. It appears the original was supposed to be "su" (maybe to capture the plural sense of "you all").

We tend to address the user with the familiar "tu" in majority of the app, so I edited accordingly; but there are inconsistencies in our usage which need to be addressed eventually.