### PR TITLE
[PRO-300] Change agent rating category "Availability" to "Available"

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -212,7 +212,7 @@
         "helperRight": "Very respectful"
       },
       "availability": {
-        "title": "Availability",
+        "title": "Available",
         "titleHelper": "Is this officer generous with their time for you? How easy is it to access this officer? Do you feel that they are considerate of the time they spend with you?",
         "helperLeft": "Very busy",
         "helperRight": "Makes time for me"

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -150,7 +150,7 @@
         "helperRight": "Muy respetuoso"
       },
       "availability": {
-        "title": "Disponibilidad",
+        "title": "Disponible",
         "titleHelper": "¿Este agente es generoso con el tiempo que te dedica? ¿Qué tan fácil es acceder a este agente? ¿Sientes que son considerados con el tiempo que pasan contigo?",
         "helperLeft": "Muy ocupado",
         "helperRight": "Hace tiempo para mi"


### PR DESCRIPTION
Changes "Availability" to "Available" for grammatical consistency across agent rating categories (all the others are adjectives).

<h3>Before</h3>
<img src="https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/5b0acec3-c49e-4882-8e94-b9e67aeb341a">
<img src="https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/34152a9a-5887-4b4f-ac4b-15f438bdcc8a">


<h3>After</h3>
<img src="https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/5c30d85e-c50d-4052-b28f-28f102cb1939">
<img src="https://github.com/ProjectProtocol/project-protocol-web/assets/116319343/aae3a351-4bec-41e1-b34b-1e746cf04ccc">

