### PR TITLE
Hotfix: tolgee script

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+## 🛠️ Changes
+
+**describe changes made to user experience and/or notable changes to the codebase**
+
+## 🧪 Testing
+
+**Include testing instructions for reviewers here**

--- a/scripts/tolgee-pull
+++ b/scripts/tolgee-pull
@@ -1,8 +1,8 @@
 # install Tolgee cli
-npm i -g @tolgee/cli
+npm i -g @tolgee/cli@2.0.1
 
 # login to tolgee platform
 tolgee login $TOLGEE_ACCESS_TOKEN
 
 # pull translation files to ./i18n folder
-tolgee --project-id 7020 pull -o ./public/i18n
+tolgee pull --path ./public/i18n --project-id 7020 --empty-dir


### PR DESCRIPTION
We didn't specify a tolgee/cli version in the script. The script was using options that only existed before v2 but the Netlify build process was installing the latest one (v2.0.1). I had v1.4.0 installed locally somehow. This adds an explicit version to the script so this shouldn't happen again.

- Pin tolgee/cli to version and update command syntax
- Add pull-request template while I'm at it
