### PR TITLE
[PRO-331] Fixes confirmation modal title

### DIFF
--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -131,7 +131,9 @@ export default function AgentView() {
       <ConfirmationModal
         show={showConfirmToRateModal}
         onHide={() => setShowConfirmToRateModal(false)}
-        title={t('confirmationModal.title')}
+        title={t('confirmationModal.title', {
+          ns: 'home',
+        })}
         bodyClass="px-4"
         user={user}
         closeButton


### PR DESCRIPTION
## 🛠️ Changes

* Fixed translated string missing namespace for confirmation modal.

## 🧪 Testing

1. Create an account
2. Do not confirm
3. Log into account
4. Go to rate an agent
5. It should pop up the confirmation modal with the broken title.
