### PR TITLE
Changing the submit message based on comment entered

### DIFF
--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -29,7 +29,7 @@ export default function RateAgentModal({
     control,
     register,
     reset,
-    formState: { errors, isSubmitting },
+    formState: { errors, isSubmitting, dirtyFields },
   } = useForm<IRateAgentFormState>({
     mode: 'onSubmit',
     defaultValues: {
@@ -106,7 +106,8 @@ export default function RateAgentModal({
         </div>
         <div className="d-grid gap-3">
           <AsyncButton loading={isSubmitting} size="lg" type="submit">
-            {t('submit')}
+            {!dirtyFields.reviewInput && t('submit', { ns: 'shared' })}
+            {dirtyFields.reviewInput && t('submit')}
           </AsyncButton>
           <Button size="lg" onClick={onHide} variant="link link-danger">
             {t('cancel', { ns: 'shared' })}


### PR DESCRIPTION
## 🛠️ Changes

This updates the Submit text to use Submit for review only if a person has entered anything in the review input. Otherwise, Submit is used.

## 🧪 Testing
Start off with blank comment
<img width="412" alt="截屏2024-06-14 上午11 54 01" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/30710bce-e338-4194-9348-3783c1e0d6f7">
Start typing something
<img width="409" alt="截屏2024-06-14 上午11 54 09" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/1b0d4720-7635-4d84-a317-c015bb5ec9ea">


