### PR TITLE
Adding a tooltip for help guidelines for additional comments

### DIFF
--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -1,4 +1,10 @@
-import { Alert, Button, FormControl } from 'react-bootstrap'
+import {
+  Alert,
+  Button,
+  FormControl,
+  OverlayTrigger,
+  Popover,
+} from 'react-bootstrap'
 import Agent from '../../types/Agent'
 import AgentInfo from '../AgentInfo'
 import { IRateAgentFormState } from './form-types'
@@ -80,7 +86,19 @@ export default function RateAgentModal({
           <h4>
             {t('additionalComments') + ' ' + t('optional', { ns: 'shared' })}
           </h4>
-          <p>{t('additionalCommentsHelpText')}</p>
+          <p>
+            {t('additionalCommentsHelpText')}
+            <OverlayTrigger
+              placement="right"
+              overlay={
+                <Popover>
+                  <Popover.Body>{t('additionalCommentsTooltip')}</Popover.Body>
+                </Popover>
+              }
+            >
+              <i className="bi bi-info-circle"></i>
+            </OverlayTrigger>
+          </p>
           <FormControl
             as="textarea"
             placeholder={t('additionalCommentsPlaceholder')}

--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -96,7 +96,7 @@ export default function RateAgentModal({
                 </Popover>
               }
             >
-              <i className="bi bi-info-circle"></i>
+              <i className="bi bi-info-circle ms-1"></i>
             </OverlayTrigger>
           </p>
           <FormControl


### PR DESCRIPTION
## 🛠️ Changes

Adding a tooltip (using Popover) as a way to explain why additional comments are hidden until approved. The text is in Tolgee and can be workshopped. 

## 🧪 Testing
On hover next to the icon, this popup shows up.
<img width="422" alt="截屏2024-06-17 上午11 21 44" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/0e693be5-a9ad-49f8-b566-a9845de099b3">

