### PR TITLE
Adding a safeguard at the end of the rate agent modal for checking current parole

### DIFF
--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -90,7 +90,7 @@ export default function RateAgentModal({
         <RateAgentRatingRadio control={control} name="respectful" />
         <RateAgentRatingRadio control={control} name="availability" />
         <RateAgentTags control={control} />
-        <div className="mb-5">
+        <div className="mb-4">
           <h4>{t('currentlyOnParole')}</h4>
           <FormCheck
             type="radio"
@@ -107,7 +107,7 @@ export default function RateAgentModal({
             required
           ></FormCheck>
         </div>
-        <div className="mb-5">
+        <div className="mb-4">
           <h4 className={isCurrentlyOnParole ? 'text-muted' : ''}>
             {t('additionalComments') + ' ' + t('optional', { ns: 'shared' })}
           </h4>

--- a/src/components/RateAgentModal/index.tsx
+++ b/src/components/RateAgentModal/index.tsx
@@ -4,6 +4,7 @@ import {
   FormControl,
   OverlayTrigger,
   Popover,
+  FormCheck,
 } from 'react-bootstrap'
 import Agent from '../../types/Agent'
 import AgentInfo from '../AgentInfo'
@@ -16,6 +17,7 @@ import { isEmpty } from 'lodash-es'
 import PopUp from '../PopUp'
 import AsyncButton from '../AsyncButton'
 import { useTranslate } from '@tolgee/react'
+import { useState } from 'react'
 
 interface IRateAgentModal {
   agent: Agent
@@ -64,6 +66,12 @@ export default function RateAgentModal({
     reset()
   }
 
+  const [isCurrentlyOnParole, setIsCurrentlyOnParole] = useState(false)
+
+  const onClick = (value: boolean) => {
+    setIsCurrentlyOnParole(value)
+  }
+
   return (
     <PopUp
       title={t('title')}
@@ -83,10 +91,27 @@ export default function RateAgentModal({
         <RateAgentRatingRadio control={control} name="availability" />
         <RateAgentTags control={control} />
         <div className="mb-5">
-          <h4>
+          <h4>{t('currentlyOnParole')}</h4>
+          <FormCheck
+            type="radio"
+            label="No"
+            name="currentlyOnParole"
+            onChange={() => onClick(false)}
+            required
+          ></FormCheck>
+          <FormCheck
+            type="radio"
+            label="Yes"
+            name="currentlyOnParole"
+            onChange={() => onClick(true)}
+            required
+          ></FormCheck>
+        </div>
+        <div className="mb-5">
+          <h4 className={isCurrentlyOnParole ? 'text-muted' : ''}>
             {t('additionalComments') + ' ' + t('optional', { ns: 'shared' })}
           </h4>
-          <p>
+          <p className={isCurrentlyOnParole ? 'text-muted' : ''}>
             {t('additionalCommentsHelpText')}
             <OverlayTrigger
               placement="right"
@@ -101,8 +126,13 @@ export default function RateAgentModal({
           </p>
           <FormControl
             as="textarea"
-            placeholder={t('additionalCommentsPlaceholder')}
+            placeholder={
+              isCurrentlyOnParole
+                ? t('additionalCommentsDisabled')
+                : t('additionalCommentsPlaceholder')
+            }
             rows={2}
+            disabled={isCurrentlyOnParole}
             {...register('reviewInput')}
           />
         </div>


### PR DESCRIPTION
## 🛠️ Changes

We do not want people who are rating their current officer to add comments. This adds a radio selection that when toggled, will affect the disabled state of the comments form area (turn the text muted, update the form placeholder text).

## 🧪 Testing

<img width="423" alt="截屏2024-06-18 上午11 45 39" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/0a230d1a-9803-49db-9c53-ed05aa3da2a7">
<img width="418" alt="截屏2024-06-18 上午11 45 43" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/d412225e-7ccd-4fde-a5d2-9d77f16ce3ab">

