### PR TITLE
Front End changes to support Tolgee usage of password reset

### DIFF
--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -77,7 +77,9 @@ export default function LoginModal({
       toast.success(
         (to) => (
           <span>
-            {t(`${result?.message}`, { ns: 'password_reset' })}
+            {result?.message && result?.message.includes(' ')
+              ? result?.message
+              : t(`${result?.message}`, { ns: 'password_reset' })}
             <Button
               size="sm"
               variant="link"

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -28,7 +28,7 @@ export default function LoginModal({
   ...props
 }: LoginModal) {
   const { user, setUser } = useAuth()
-  const { t } = useTranslate(['login', 'shared'])
+  const { t } = useTranslate(['login', 'shared', 'password_reset'])
   const navigate = useNavigate()
 
   const logIn = async ({ email, password }: ILoginFormState) => {
@@ -77,9 +77,7 @@ export default function LoginModal({
       toast.success(
         (to) => (
           <span>
-            {result?.message && result?.message.includes(' ')
-              ? result?.message
-              : t(result?.message, { ns: 'password_reset' })}
+            {t(`${result?.message}`, { ns: 'password_reset' })}
             <Button
               size="sm"
               variant="link"

--- a/src/components/LoginModal/index.tsx
+++ b/src/components/LoginModal/index.tsx
@@ -75,13 +75,15 @@ export default function LoginModal({
     const result = await ApiPasswordResets.create({ email })
     if (result) {
       toast.success(
-        (t) => (
+        (to) => (
           <span>
-            {result?.message}
+            {result?.message && result?.message.includes(' ')
+              ? result?.message
+              : t(result?.message, { ns: 'password_reset' })}
             <Button
               size="sm"
               variant="link"
-              onClick={() => toast.dismiss(t.id)}
+              onClick={() => toast.dismiss(to.id)}
             >
               Dismiss
             </Button>

--- a/src/pages/PasswordResets.tsx
+++ b/src/pages/PasswordResets.tsx
@@ -22,7 +22,7 @@ export default function PasswordResets() {
     async function validateToken() {
       const isValid = await ApiPasswordResets.get(token || '')
       if (!isValid) {
-        toast.error('Password reset has expired, please try again', {
+        toast.error(t('expiredToken'), {
           id: 'invalid-pw-reset-token',
         })
         navigate('/', { replace: true })
@@ -35,7 +35,7 @@ export default function PasswordResets() {
     newPassword,
     newPasswordConfirm,
   }: IPasswordResetsFormState) => {
-    if (token === undefined) throw new Error('Invalid request')
+    if (token === undefined) throw new Error(t('invalidToken'))
 
     const result = await ApiPasswordResets.update({
       newPassword,
@@ -45,7 +45,7 @@ export default function PasswordResets() {
     if (result) {
       setSuccess(true)
     } else {
-      toast.error('Password change failed, please try again.')
+      toast.error(t('resetRequestError'))
       navigate('/', { replace: true })
     }
   }

--- a/src/pages/PasswordResets.tsx
+++ b/src/pages/PasswordResets.tsx
@@ -29,7 +29,7 @@ export default function PasswordResets() {
       }
     }
     validateToken()
-  }, [token, navigate])
+  }, [token, navigate, t])
 
   const updatePassword = async ({
     newPassword,


### PR DESCRIPTION
## 🛠️ Changes

The Tolgee key should not have any spaces, so if there is a space, then we use that message as / is vs. using the Tolgee translation. In addition, I noticed that there were several places in the API layer that required Tolgee usage rather than raw strings, so I replaced them with their counterparts.

## 🧪 Testing

<img width="385" alt="截屏2024-06-20 下午12 51 24" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/33f5e515-3f63-42d2-9828-335d38a0eec6">

