### PR TITLE
Frontend implementation of the policy acknowledged field

### DIFF
--- a/src/api/profile.ts
+++ b/src/api/profile.ts
@@ -17,3 +17,12 @@ export async function update({
 
   return result
 }
+
+export async function acknowledgePolicy() {
+  const result = await apiClient
+    .patch('/profile/policy')
+    .then((r) => 400 > r.status && r.status >= 200)
+    .catch(() => false)
+
+  return result
+}

--- a/src/components/ModerationInfoModal.tsx
+++ b/src/components/ModerationInfoModal.tsx
@@ -1,10 +1,18 @@
 import { Link } from 'react-router-dom'
 import PopUp, { IPopUp } from './PopUp'
 import logo from 'src/images/icon.svg'
+import { Button } from 'react-bootstrap'
+import { ApiProfile } from 'src/api'
 
 export default function ModerationInfoModal(props: IPopUp) {
+  const acknowledgePolicy = async () => {
+    const result = await ApiProfile.acknowledgePolicy()
+    if (result) {
+      props.onHide?.()
+    }
+  }
   return (
-    <PopUp {...props} closeButton>
+    <PopUp {...props} closeButton={props.closeButton}>
       <div style={{ maxWidth: '300px', margin: '0 auto' }}>
         <div className="d-flex flex-column align-items-center justify-content-center vertical-rhythm">
           <img src={logo} width="50" />
@@ -42,9 +50,14 @@ export default function ModerationInfoModal(props: IPopUp) {
             .
           </p>
         </div>
-        <div className="mt-5 text-center">
+        <div className="mt-3 text-center">
           <Link to="/terms-of-service">Read our terms of service</Link>
         </div>
+        {!props.closeButton && (
+          <div className="text-center">
+            <Button onClick={acknowledgePolicy}>I understand</Button>
+          </div>
+        )}
       </div>
     </PopUp>
   )

--- a/src/components/ModerationInfoModal.tsx
+++ b/src/components/ModerationInfoModal.tsx
@@ -49,15 +49,15 @@ export default function ModerationInfoModal(props: IPopUp) {
             </a>
             .
           </p>
-        </div>
-        <div className="mt-3 text-center">
-          <Link to="/terms-of-service">Read our terms of service</Link>
-        </div>
-        {!props.closeButton && (
           <div className="text-center">
-            <Button onClick={acknowledgePolicy}>I understand</Button>
+            <Link to="/terms-of-service">Read our terms of service</Link>
           </div>
-        )}
+          {!props.closeButton && (
+            <div className="text-center">
+              <Button onClick={acknowledgePolicy}>I understand</Button>
+            </div>
+          )}
+        </div>
       </div>
     </PopUp>
   )

--- a/src/pages/AgentView.tsx
+++ b/src/pages/AgentView.tsx
@@ -140,6 +140,7 @@ export default function AgentView() {
       />
       <ModerationInfoModal
         show={showModerationModal}
+        closeButton={true}
         onHide={() => setShowModerationModal(false)}
       />
     </>

--- a/src/pages/Search.tsx
+++ b/src/pages/Search.tsx
@@ -16,6 +16,7 @@ import { InView } from 'react-intersection-observer'
 import useLoadingBar from 'src/hooks/useLoadingBar'
 import PageHeader from 'src/components/PageHeader'
 import { T, useTranslate } from '@tolgee/react'
+import ModerationInfoModal from 'src/components/ModerationInfoModal'
 
 export default function Search() {
   const [params] = useSearchParams()
@@ -46,9 +47,12 @@ export default function Search() {
   const submit = useSubmit()
   const navigate = useNavigate()
   const { t } = useTranslate('rate_my_po')
-  const { user } = useAuth()
+  const { user, refreshUser } = useAuth()
   const { openLogin } = useLogin()
   const [showConfirmModal, setShowConfirmModal] = useState(false)
+  const [showModerationModal, setShowModerationModal] = useState(
+    !user?.isPolicyAcknowledged,
+  )
 
   useEffect(() => {
     const searchEl = document.getElementById('search') as HTMLInputElement
@@ -64,6 +68,11 @@ export default function Search() {
     const resultType = r.type
     const targetUrl = `/${resultType.toLowerCase()}s/${r.id}`
     return () => navigate(targetUrl, { state: { [resultType]: r } })
+  }
+
+  const handleClick = () => {
+    refreshUser()
+    setShowModerationModal(false)
   }
 
   return (
@@ -138,6 +147,13 @@ export default function Search() {
             user={user}
             closeButton
           />
+        )}
+        {user && (
+          <ModerationInfoModal
+            show={showModerationModal}
+            closeButton={false}
+            onHide={handleClick}
+          ></ModerationInfoModal>
         )}
       </div>
     </div>

--- a/src/types/User.ts
+++ b/src/types/User.ts
@@ -2,6 +2,7 @@ type User = {
   email: string
   isConfirmed: boolean
   confirmationSentAt?: string
+  isPolicyAcknowledged: boolean
 }
 
 export default User


### PR DESCRIPTION
## 🛠️ Changes

This uses the moderation modal to display when a user logs in and hasn't yet acknowledged policy yet. It then doesn't display again when the user navigates back to another page. It is slightly modified from the version shown to users after they leave a comment.

## 🧪 Testing
<img width="1171" alt="截屏2024-07-08 下午12 12 26" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/c6184363-8eba-4ee1-9c63-ef4b2eb4dad6">
<img width="1121" alt="截屏2024-07-08 下午12 12 38" src="https://github.com/ProjectProtocol/project-protocol-web/assets/5348488/94a36864-01ca-4d2f-b95b-847f15c5813e">

